### PR TITLE
Fix resume

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ pub async fn cli(command: Commands, app_state: AppState, creds: Credentials) -> 
                     client.quality()
                 };
 
-                let player = player::new(app_state.clone(), client.clone());
+                let mut player = player::new(app_state.clone(), client.clone());
                 player.setup(false).await;
 
                 if let Ok(album) = client.album(selected_album.id).await {
@@ -193,8 +193,7 @@ pub async fn cli(command: Commands, app_state: AppState, creds: Credentials) -> 
             if no_tui {
                 output!(results, output_format);
             } else {
-                let player = player::new(app_state.clone(), client.clone());
-
+                let mut player = player::new(app_state.clone(), client.clone());
                 player.setup(false).await;
 
                 let mut tui = ui::terminal::new(app_state, player.controls(), no_tui)?;
@@ -257,7 +256,7 @@ pub async fn cli(command: Commands, app_state: AppState, creds: Credentials) -> 
         }
         Commands::StreamTrack { track_id, quality } => {
             let client = client::new(app_state.clone(), creds).await?;
-            let player = player::new(app_state.clone(), client.clone());
+            let mut player = player::new(app_state.clone(), client.clone());
             let track = client.track(track_id).await?;
 
             app_state.player.clear();
@@ -278,7 +277,7 @@ pub async fn cli(command: Commands, app_state: AppState, creds: Credentials) -> 
                 .await
                 .expect("failed to create client");
 
-            let player = player::new(app_state.clone(), client.clone());
+            let mut player = player::new(app_state.clone(), client.clone());
             let album = client.album(album_id).await?;
 
             app_state.player.clear();

--- a/src/player.rs
+++ b/src/player.rs
@@ -450,8 +450,21 @@ impl Player {
         }
     }
     /// Sets up basic functionality for the player.
-    pub async fn setup(&self, resume: bool) {
+    pub async fn setup(&mut self, resume: bool) {
         mpris::init(self.controls.clone()).await;
+
+        if resume {
+            let tree = self.state.player.clone();
+            if let Some(playlist) = get_player!(PlayerKey::Playlist, tree, PlaylistValue) {
+                self.playlist = Arc::new(RwLock::new(playlist));
+            }
+
+            if let Some(prev_playlist) =
+                get_player!(PlayerKey::PreviousPlaylist, tree, PlaylistValue)
+            {
+                self.playlist_previous = Arc::new(RwLock::new(prev_playlist));
+            }
+        }
 
         let cloned_self = self.clone();
         let quitter = self.app_state().quitter();


### PR DESCRIPTION
The resume feature will resume playback, but trying to skip tracks or anything crashes the app.

This fixes that issue by correctly adding back the playlists when resuming.
