### PR TITLE
Fixes state performance regression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,9 +15,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
@@ -33,9 +33,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.66"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
 name = "arrayvec"
@@ -45,9 +45,9 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "async-broadcast"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d26004fe83b2d1cd3a97609b21e39f9a31535822210fe83205d2ce48866ea61"
+checksum = "1b19760fa2b7301cf235360ffd6d3558b1ed4249edd16d6cca8d690cee265b95"
 dependencies = [
  "event-listener",
  "futures-core",
@@ -88,9 +88,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.58"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
+checksum = "705339e0e4a9690e2908d2b3d049d85682cf19fbd5782494498fbf7003a6a282"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -112,7 +112,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -128,6 +128,12 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "bigdecimal"
@@ -171,6 +177,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15bf3650200d8bffa99015595e10f1fbd17de07abbc25bb067da79e769939bfa"
+dependencies = [
+ "borsh-derive",
+ "hashbrown 0.11.2",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6441c552f230375d18e3cc377677914d2ca2b0d36e52129fe15450a2dce46775"
+dependencies = [
+ "borsh-derive-internal",
+ "borsh-schema-derive-internal",
+ "proc-macro-crate 0.1.5",
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "borsh-derive-internal"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5449c28a7b352f2d1e592a8a28bf139bc71afb0764a14f3c02500935d8c44065"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "borsh-schema-derive-internal"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "bstr"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,6 +247,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
+name = "bytecheck"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d11cac2c12b5adc6570dad2ee1b87eff4955dac476fe12d81e5fdd352e52406f"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13e576ebe98e605500b3c8041bb888e966653577172df6dd97398714eb30b9bf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,9 +275,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
 name = "cassowary"
@@ -215,9 +287,9 @@ checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "cc"
-version = "1.0.76"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a284da2e6fe2092f2353e51713435363112dfd60030e22add80be333fb928f"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
 dependencies = [
  "jobserver",
 ]
@@ -255,21 +327,21 @@ dependencies = [
  "num-traits",
  "rustc-serialize",
  "serde",
- "time 0.1.44",
+ "time 0.1.45",
  "wasm-bindgen",
  "winapi",
 ]
 
 [[package]]
 name = "clap"
-version = "4.0.24"
+version = "4.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60494cedb60cb47462c0ff7be53de32c0e42a6fc2c772184554fa12bd9489c03"
+checksum = "a7db700bc935f9e43e88d00b0850dae18a63773cfbec6d8e070fccf7fef89a39"
 dependencies = [
- "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
+ "is-terminal",
  "once_cell",
  "strsim",
  "termcolor",
@@ -319,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "6.1.2"
+version = "6.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1090f39f45786ec6dc6286f8ea9c75d0a7ef0a0d3cda674cef0c3af7b307fbc2"
+checksum = "6e7b787b0dc42e8111badfdbe4c3059158ccb2db8780352fa1b01e8ccf45cc4d"
 dependencies = [
  "crossterm",
  "strum",
@@ -331,23 +403,22 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.2"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c050367d967ced717c04b65d8c619d863ef9292ce0c5760028655a2fb298718c"
+checksum = "c9b6515d269224923b26b5febea2ed42b2d5f2ce37284a4dd670fedd6cb8347a"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
- "terminal_size",
  "unicode-width",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
 name = "cookie"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "344adc371239ef32293cb1c4fe519592fcf21206c79c02854320afcdf3ab4917"
+checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
 dependencies = [
  "percent-encoding",
  "time 0.3.17",
@@ -406,72 +477,15 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d0165d2900ae6778e36e80bbc4da3b5eefccee9ba939761f9c2882a5d9af3ff"
-
-[[package]]
-name = "crc32fast"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "crossbeam"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
-dependencies = [
- "cfg-if",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
-dependencies = [
- "cfg-if",
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348"
-dependencies = [
- "autocfg",
- "cfg-if",
- "crossbeam-utils",
- "memoffset",
- "scopeguard",
-]
+checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd42583b04998a5363558e5f9291ee5a5ff6b49944332103f251e7479a82aa7"
+checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -479,9 +493,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
  "cfg-if",
 ]
@@ -523,12 +537,12 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.2.3"
+version = "3.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d91974fbbe88ec1df0c24a4f00f99583667a7e2e6272b2b92d294d81e462173"
+checksum = "1631ca6e3c59112501a9d87fd86f21591ff77acd31331e8a73f8d80a65bbdd71"
 dependencies = [
- "nix 0.25.0",
- "winapi",
+ "nix 0.26.1",
+ "windows-sys",
 ]
 
 [[package]]
@@ -539,9 +553,9 @@ checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
 name = "cxx"
-version = "1.0.81"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97abf9f0eca9e52b7f81b945524e76710e6cb2366aead23b7d4fbf72e281f888"
+checksum = "51d1075c37807dcf850c379432f0df05ba52cc30f279c5cfc43cc221ce7f8579"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -551,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.81"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc32cc5fea1d894b77d269ddb9f192110069a8a9c1f1d441195fba90553dea3"
+checksum = "5044281f61b27bc598f2f6647d480aed48d2bf52d6eb0b627d84c0361b17aa70"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -566,15 +580,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.81"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca220e4794c934dc6b1207c3b42856ad4c302f2df1712e9f8d2eec5afaacf1f"
+checksum = "61b50bc93ba22c27b0d31128d2d130a0a6b3d267ae27ef7e4fae2167dfe8781c"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.81"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b846f081361125bfc8dc9d3940c84e1fd83ba54bbca7b17cd29483c828be0704"
+checksum = "39e61fda7e62115119469c7b3591fd913ecca96fb766cfd3f2e2502ab7bc87a5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -606,9 +620,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -683,6 +697,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum_dispatch"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb609da60cb562dcb49cd458d42d0d8501d2312aa56dd246911472f9422db017"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "enumflags2"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,6 +740,27 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -772,16 +819,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -894,15 +931,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -966,7 +994,7 @@ checksum = "25a68131a662b04931e71891fb14aaf65ee4b44d08e8abc10f49e77418c86c64"
 dependencies = [
  "anyhow",
  "heck",
- "proc-macro-crate",
+ "proc-macro-crate 1.2.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -1140,6 +1168,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
@@ -1153,7 +1190,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69fe1fcf8b4278d860ad0548329f892a3631fb63f82574df68275f34cdbe0ffa"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1162,7 +1199,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bitflags",
  "bytes",
  "headers-core",
@@ -1200,6 +1237,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1209,13 +1255,13 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 name = "hifi-rs"
 version = "0.1.0"
 dependencies = [
- "base64",
+ "async-trait",
+ "base64 0.13.1",
  "bincode",
  "byteorder",
  "chrono",
  "clap",
  "comfy-table",
- "crossbeam",
  "ctrlc",
  "dialoguer",
  "dirs",
@@ -1231,7 +1277,6 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sled",
  "snafu",
  "sqlx",
  "termion",
@@ -1371,12 +1416,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1393,9 +1438,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.21.1"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1e75aa1530e7385af7b2685478dece08dafb9db3b4225c753286decea83bef"
+checksum = "f6f0f08b46e4379744de2ab67aa8f7de3ffd1da3e275adc41fcc82053ede46ff"
 dependencies = [
  "console",
  "lazy_static",
@@ -1417,16 +1462,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipnet"
-version = "2.5.1"
+name = "io-lifetimes"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
+checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "ipnetwork"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f84f1612606f3753f205a4e9a2efd6fe5b4c573a6269b2cc6c3003d44a0d127"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys",
+]
 
 [[package]]
 name = "itertools"
@@ -1439,9 +1506,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "jni"
@@ -1489,9 +1556,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libgit2-sys"
@@ -1530,9 +1597,9 @@ dependencies = [
 
 [[package]]
 name = "link-cplusplus"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
 dependencies = [
  "cc",
 ]
@@ -1542,6 +1609,12 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "lock_api"
@@ -1568,7 +1641,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b238e3235c8382b7653c6408ed1b08dd379bdb9fdf990fb0bbae3db2cc0ae963"
 dependencies = [
- "nix 0.23.1",
+ "nix 0.23.2",
  "winapi",
 ]
 
@@ -1650,7 +1723,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1721,9 +1794,9 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nix"
-version = "0.23.1"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
+checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
 dependencies = [
  "bitflags",
  "cc",
@@ -1734,9 +1807,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e322c04a9e3440c327fca7b6c8a63e6890a32fa2ad689db972425f07e0d22abb"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
 dependencies = [
  "autocfg",
  "bitflags",
@@ -1747,10 +1820,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "nom"
-version = "7.1.1"
+name = "nix"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+checksum = "46a58d1d356c6597d08cde02c2f09d785b09e28711837b1ed667dc652c08a694"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "static_assertions",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5507769c4919c998e69e49c839d9dc6e693ede4cc4290d6ad8b41d4f09c548c"
 dependencies = [
  "memchr",
  "minimal-lexical",
@@ -1800,11 +1885,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
@@ -1831,15 +1916,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "openssl"
-version = "0.10.42"
+version = "0.10.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12fc0523e3bd51a692c8850d075d74dc062ccf251c0110668cbd921917118a13"
+checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1869,9 +1954,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.77"
+version = "0.9.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03b84c3b2d099b81f0953422b4d4ad58761589d0229b5506356afca05a3670a"
+checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
 dependencies = [
  "autocfg",
  "cc",
@@ -1891,9 +1976,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-stream"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034ce384018b245e8d8424bbe90577fbd91a533be74107e465e3474eb2285eef"
+checksum = "d4eb9ba3f3e42dbdd3b7b122de5ca169c81e93d561eb900da3a8c99bcfcf381a"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -1901,9 +1986,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.4.0"
+version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5bf27447411e9ee3ff51186bf7a08e16c341efdde93f4d823e8844429bed7e"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "parking_lot"
@@ -1913,7 +1998,7 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core 0.8.5",
+ "parking_lot_core 0.8.6",
 ]
 
 [[package]]
@@ -1923,14 +2008,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.4",
+ "parking_lot_core 0.9.6",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
 dependencies = [
  "cfg-if",
  "instant",
@@ -1942,22 +2027,22 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.4"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
+checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "paste"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
+checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
 
 [[package]]
 name = "percent-encoding"
@@ -1967,9 +2052,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.4.1"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a528564cc62c19a7acac4d81e01f39e53e25e17b934878f4c6d25cc2836e62f8"
+checksum = "4257b4a04d91f7e9e6290be5d3da4804dd5784fafde3a497d73eb2b4a158c30a"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -1977,9 +2062,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.4.1"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fd9bc6500181952d34bd0b2b0163a54d794227b498be0b7afa7698d0a7b18f"
+checksum = "241cda393b0cdd65e62e07e12454f1f25d57017dcc514b1514cd3c4645e3a0a6"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1987,9 +2072,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.4.1"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2610d5ac5156217b4ff8e46ddcef7cdf44b273da2ac5bca2ecbfa86a330e7c4"
+checksum = "46b53634d8c8196302953c74d5352f33d0c512a9499bd2ce468fc9f4128fa27c"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2000,13 +2085,13 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.4.1"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824749bf7e21dd66b36fbe26b3f45c713879cccd4a009a917ab8e045ca8246fe"
+checksum = "0ef4f1332a8d4678b41966bb4cc1d0676880e84183a1ecc3f4b69f03e99c7a51"
 dependencies = [
  "once_cell",
  "pest",
- "sha1",
+ "sha2",
 ]
 
 [[package]]
@@ -2068,9 +2153,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "0.3.15"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15eb2c6e362923af47e13c23ca5afb859e83d54452c55b0b9ac763b8f7c1ac16"
+checksum = "26f6a7b87c2e435a3241addceeeff740ff8b7e76b74c13bf9acb17fa454ea00b"
 
 [[package]]
 name = "ppv-lite86"
@@ -2092,6 +2177,15 @@ checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
 dependencies = [
  "env_logger",
  "log",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
+dependencies = [
+ "toml",
 ]
 
 [[package]]
@@ -2131,15 +2225,15 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.19"
+version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]
@@ -2149,6 +2243,26 @@ name = "psl-types"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "publicsuffix"
@@ -2164,7 +2278,7 @@ dependencies = [
 name = "qobuz-client"
 version = "0.1.0"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bincode",
  "byteorder",
  "chrono",
@@ -2198,9 +2312,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -2275,9 +2389,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2300,12 +2414,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest"
-version = "0.11.12"
+name = "rend"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
+checksum = "79af64b4b6362ffba04eef3a4e10829718a4896dac19daa741851c86781edf95"
 dependencies = [
- "base64",
+ "bytecheck",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
+dependencies = [
+ "base64 0.13.1",
  "bytes",
  "cookie",
  "cookie_store",
@@ -2358,14 +2481,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "rspotify"
-version = "0.11.5"
+name = "rkyv"
+version = "0.7.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1e20ceabb52376647badaaf6d65dd068c963537dd82c705cd0af7621132a0bb"
+checksum = "cec2b3485b07d96ddfd3134767b8a447b45ea4eb91448d0a35180ec0ffd5ed15"
+dependencies = [
+ "bytecheck",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eaedadc88b53e36dd32d940ed21ae4d850d5916f2581526921f553a72ac34c4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "rspotify"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a86007448fb9a88a0677fd332addf8e7c1057e67bc385d3477c8d44c1bb0e96f"
 dependencies = [
  "async-stream",
  "async-trait",
- "base64",
+ "base64 0.13.1",
  "chrono",
  "futures",
  "getrandom",
@@ -2383,9 +2531,9 @@ dependencies = [
 
 [[package]]
 name = "rspotify-http"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe28fe911336a08629c48241988d9f6f338babb69ef18d00d9bfdc7280ceb95"
+checksum = "aa7481b3155d1ee3a0a73f94148d3385487e519b795d418ec0df1588961c1105"
 dependencies = [
  "async-trait",
  "log",
@@ -2397,17 +2545,18 @@ dependencies = [
 
 [[package]]
 name = "rspotify-macros"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47716be06c31041cca54ba9023e205969a91825b84f7196bbb60724b1e6fdfa9"
+checksum = "0c86521fc751c75235937f0014dfb17e67f8abc6461b28ad82c9c2acc33a0c47"
 
 [[package]]
 name = "rspotify-model"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989a2221f58bd204ab6f3f98681511dc94eb843c5ae5db379012fc1769853736"
+checksum = "3b03296b02fc44c9b792635cf8156d13b9d0edf629d74e80c4f551a97a1b83cd"
 dependencies = [
  "chrono",
+ "enum_dispatch",
  "serde",
  "serde_json",
  "strum",
@@ -2416,13 +2565,20 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.26.1"
+version = "1.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee9164faf726e4f3ece4978b25ca877ddc6802fa77f38cdccb32c7f805ecd70c"
+checksum = "33c321ee4e17d2b7abe12b5d20c1231db708dd36185c8a21e9de5fed6da4dbe9"
 dependencies = [
  "arrayvec",
+ "borsh",
+ "bytecheck",
+ "byteorder",
+ "bytes",
  "num-traits",
+ "rand",
+ "rkyv",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2430,6 +2586,20 @@ name = "rustc-serialize"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+
+[[package]]
+name = "rustix"
+version = "0.36.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "rustls"
@@ -2449,29 +2619,29 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
 dependencies = [
- "base64",
+ "base64 0.13.1",
 ]
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64",
+ "base64 0.21.0",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "safemem"
@@ -2490,12 +2660,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
+checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
- "lazy_static",
- "windows-sys 0.36.1",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2512,9 +2681,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scratch"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
 
 [[package]]
 name = "sct"
@@ -2525,6 +2694,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "security-framework"
@@ -2551,27 +2726,27 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfc50e8183eeeb6178dcb167ae34a8051d63535023ae38b5d8d12beae193d37b"
+checksum = "718dc5fff5b36f99093fc49b280cfc96ce6fc824317783bff5a1fed0c7a64819"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2580,9 +2755,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.87"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
  "itoa",
  "ryu",
@@ -2591,9 +2766,9 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fe39d9fbb0ebf5eb2c7cb7e2a47e4f462fad1379f1166b8ae49ad9eae89a7ca"
+checksum = "9a5ec9fa74a20ebbe5d9ac23dac1fc96ba0ecfe9f50f2843b52e537b10fbcb4e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2614,9 +2789,9 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2691,23 +2866,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sled"
-version = "0.34.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f96b4737c2ce5987354855aed3797279def4ebf734436c6aa4552cf8e169935"
-dependencies = [
- "crc32fast",
- "crossbeam-epoch",
- "crossbeam-utils",
- "fs2",
- "fxhash",
- "libc",
- "log",
- "parking_lot 0.11.2",
- "zstd",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2721,9 +2879,9 @@ checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
 
 [[package]]
 name = "snafu"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152ba99b054b22972ee794cf04e5ef572da1229e33b65f3c57abbff0525a454"
+checksum = "cb0656e7e3ffb70f6c39b3c2a86332bb74aa3c679da781642590f3c1118c5045"
 dependencies = [
  "doc-comment",
  "snafu-derive",
@@ -2731,9 +2889,9 @@ dependencies = [
 
 [[package]]
 name = "snafu-derive"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5e79cdebbabaebb06a9bdbaedc7f159b410461f63611d4d0e3fb0fab8fed850"
+checksum = "475b3bbe5245c26f2d8a6f62d67c1f30eb9fffeccee721c45d162c3ebbdf81b2"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2830,7 +2988,7 @@ dependencies = [
  "percent-encoding",
  "rust_decimal",
  "rustls",
- "rustls-pemfile 1.0.1",
+ "rustls-pemfile 1.0.2",
  "serde",
  "serde_json",
  "sha2",
@@ -2925,9 +3083,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2971,16 +3129,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "terminal_size"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "termion"
 version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3005,18 +3153,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3034,9 +3182,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
@@ -3087,9 +3235,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.21.2"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
+checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3102,14 +3250,15 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "winapi",
+ "tracing",
+ "windows-sys",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3201,9 +3350,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
 dependencies = [
  "serde",
 ]
@@ -3249,9 +3398,9 @@ dependencies = [
 
 [[package]]
 name = "try-lock"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "tui"
@@ -3272,7 +3421,7 @@ version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "byteorder",
  "bytes",
  "http",
@@ -3296,9 +3445,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "ucd-trie"
@@ -3333,9 +3482,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-linebreak"
@@ -3343,7 +3492,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5faade31a542b8b35855fff6e8def199853b2da8da256da52f52f1316ee3137"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.12.3",
  "regex",
 ]
 
@@ -3403,9 +3552,9 @@ version = "0.1.0"
 
 [[package]]
 name = "uuid"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb41e78f93363bb2df8b0e86a2ca30eed7806ea16ea0c790d757cf93f79be83"
+checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
 
 [[package]]
 name = "vcpkg"
@@ -3567,18 +3716,20 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0cc7962b5aaa0dfcebaeef0161eec6edf5f4606c12e6777fd7d392f52033a5"
+checksum = "e74f5ff7786c4c21f61ba8e30ea29c9745f06fca0a4a02d083b3c662583399e8"
 dependencies = [
+ "core-foundation",
+ "dirs",
  "jni",
+ "log",
  "ndk-context",
  "objc",
  "raw-window-handle",
  "url",
  "web-sys",
- "widestring",
- "winapi",
+ "windows",
 ]
 
 [[package]]
@@ -3593,18 +3744,12 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.5"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368bfe657969fb01238bb756d351dcade285e0f6fcbd36dcb23359a5169975be"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
 ]
-
-[[package]]
-name = "widestring"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "653f141f39ec16bba3c5abe400a0c60da7468261cc2cbf36805022876bc721a8"
 
 [[package]]
 name = "winapi"
@@ -3638,16 +3783,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-sys"
-version = "0.36.1"
+name = "windows"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+checksum = "04662ed0e3e5630dfa9b26e4cb823b817f1a9addda855d973a9458c236556244"
 dependencies = [
- "windows_aarch64_msvc 0.36.1",
- "windows_i686_gnu 0.36.1",
- "windows_i686_msvc 0.36.1",
- "windows_x86_64_gnu 0.36.1",
- "windows_x86_64_msvc 0.36.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -3657,12 +3804,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.0",
- "windows_i686_gnu 0.42.0",
- "windows_i686_msvc 0.42.0",
- "windows_x86_64_gnu 0.42.0",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.0",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -3673,21 +3820,9 @@ checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3697,21 +3832,9 @@ checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3724,12 +3847,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3757,9 +3874,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "3.4.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78a0b85c5608c27d2306d67e955b9c6e23a42d824205c85038a7afbe19c0ae22"
+checksum = "379d587c0ccb632d1179cf44082653f682842f0535f0fdfaefffc34849cc855e"
 dependencies = [
  "async-broadcast",
  "async-recursion",
@@ -3774,7 +3891,7 @@ dependencies = [
  "futures-util",
  "hex",
  "lazy_static",
- "nix 0.25.0",
+ "nix 0.25.1",
  "once_cell",
  "ordered-stream",
  "rand",
@@ -3793,11 +3910,11 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "3.4.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b18018648e7e10ed856809befe7309002b87b2b12d5b282cb5040d7974b58677"
+checksum = "66492a2e90c0df7190583eccb8424aa12eb7ff06edea415a4fff6688fae18cf8"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.2.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -3806,9 +3923,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_names"
-version = "2.2.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a408fd8a352695690f53906dc7fd036be924ec51ea5e05666ff42685ed0af5"
+checksum = "f34f314916bd89bdb9934154627fab152f4f28acdda03e7c4c68181b214fe7e3"
 dependencies = [
  "serde",
  "static_assertions",
@@ -3843,39 +3960,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
 
 [[package]]
-name = "zstd"
-version = "0.9.2+zstd.1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2390ea1bf6c038c39674f22d95f0564725fc06034a47129179810b2fc58caa54"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "4.1.3+zstd.1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e99d81b99fb3c2c2c794e3fe56c305c63d5173a16a46b5850b07c935ffc7db79"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "1.6.2+zstd.1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2daf2f248d9ea44454bfcb2516534e8b8ad2fc91bf818a1885495fc42bc8ac9f"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "zvariant"
-version = "3.7.1"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b794fb7f59af4105697b0449ba31731ee5dbb3e773a17dbdf3d36206ea1b1644"
+checksum = "576cc41e65c7f283e5460f5818073e68fb1f1631502b969ef228c2e03c862efb"
 dependencies = [
  "byteorder",
  "enumflags2",
@@ -3887,11 +3975,11 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "3.7.1"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd58d4b6c8e26d3dd2149c8c40c6613ef6451b9885ff1296d1ac86c388351a54"
+checksum = "0fd4aafc0dee96ae7242a24249ce9babf21e1562822f03df650d4e68c20e41ed"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.2.1",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,9 +559,9 @@ checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
 name = "cxx"
-version = "1.0.87"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b61a7545f753a88bcbe0a70de1fcc0221e10bfc752f576754fa91e663db1622e"
+checksum = "322296e2f2e5af4270b54df9e85a02ff037e271af20ba3e7fe1575515dc840b8"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -571,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.87"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f464457d494b5ed6905c63b0c4704842aba319084a0a3561cdc1359536b53200"
+checksum = "017a1385b05d631e7875b1f151c9f012d37b53491e2a87f65bff5c262b2111d8"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -586,15 +586,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.87"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c7119ce3a3701ed81aca8410b9acf6fc399d2629d057b87e2efa4e63a3aaea"
+checksum = "c26bbb078acf09bc1ecda02d4223f03bdd28bd4874edcb0379138efc499ce971"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.87"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e07508b90551e610910fa648a1878991d367064997a596135b86df30daf07e"
+checksum = "357f40d1f06a24b60ae1fe122542c1fb05d28d32acb2aed064e84bc2ad1e252e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -669,9 +669,9 @@ checksum = "03d8c417d7a8cb362e0c37e5d815f5eb7c37f79ff93707329d5a194e42e54ca0"
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 dependencies = [
  "serde",
 ]
@@ -3499,9 +3499,9 @@ checksum = "4553f467ac8e3d374bc9a177a26801e5d0f9b211aa1673fb137a403afd1c9cf5"
 
 [[package]]
 name = "toml_edit"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729bfd096e40da9c001f778f5cdecbd2957929a24e10e5883d9392220a751581"
+checksum = "56c59d8dd7d0dcbc6428bf7aa2f0e823e26e43b3c9aca15bbc9475d23e5fa12b"
 dependencies = [
  "indexmap",
  "nom8",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,9 +56,9 @@ dependencies = [
 
 [[package]]
 name = "async-recursion"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cda8f4bcc10624c4e85bc66b3f452cca98cfa5ca002dc83a16aad2367641bea"
+checksum = "3b015a331cc64ebd1774ba119538573603427eaace0a1950c423ab971f903796"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -88,9 +88,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.61"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705339e0e4a9690e2908d2b3d049d85682cf19fbd5782494498fbf7003a6a282"
+checksum = "eff18d764974428cf3a9328e23fc5c986f5fbed46e6cd4cdf42544df5d297ec1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -105,6 +105,12 @@ checksum = "d7c57d12312ff59c811c0643f4d80830505833c9ffaebd193d819392b265be8e"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "atomic_refcell"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "857253367827bd9d0fd973f0ef15506a96e79e41b0ad7aa691203a4e3214f6c8"
 
 [[package]]
 name = "atty"
@@ -242,9 +248,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.11.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "bytecheck"
@@ -334,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.32"
+version = "4.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7db700bc935f9e43e88d00b0850dae18a63773cfbec6d8e070fccf7fef89a39"
+checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -349,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.0.21"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
+checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -362,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
 dependencies = [
  "os_str_bytes",
 ]
@@ -403,9 +409,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b6515d269224923b26b5febea2ed42b2d5f2ce37284a4dd670fedd6cb8347a"
+checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
 dependencies = [
  "encode_unicode",
  "lazy_static",
@@ -541,7 +547,7 @@ version = "3.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1631ca6e3c59112501a9d87fd86f21591ff77acd31331e8a73f8d80a65bbdd71"
 dependencies = [
- "nix 0.26.1",
+ "nix 0.26.2",
  "windows-sys",
 ]
 
@@ -553,9 +559,9 @@ checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
 name = "cxx"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d1075c37807dcf850c379432f0df05ba52cc30f279c5cfc43cc221ce7f8579"
+checksum = "b61a7545f753a88bcbe0a70de1fcc0221e10bfc752f576754fa91e663db1622e"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -565,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5044281f61b27bc598f2f6647d480aed48d2bf52d6eb0b627d84c0361b17aa70"
+checksum = "f464457d494b5ed6905c63b0c4704842aba319084a0a3561cdc1359536b53200"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -580,15 +586,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b50bc93ba22c27b0d31128d2d130a0a6b3d267ae27ef7e4fae2167dfe8781c"
+checksum = "43c7119ce3a3701ed81aca8410b9acf6fc399d2629d057b87e2efa4e63a3aaea"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e61fda7e62115119469c7b3591fd913ecca96fb766cfd3f2e2502ab7bc87a5"
+checksum = "65e07508b90551e610910fa648a1878991d367064997a596135b86df30daf07e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -608,12 +614,13 @@ dependencies = [
 
 [[package]]
 name = "dialoguer"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92e7e37ecef6857fdc0c0c5d42fd5b0938e46590c2183cc92dd310a6d078eb1"
+checksum = "af3c796f3b0b408d9fd581611b47fa850821fcb84aa640b83a3c1a5be2d691f2"
 dependencies = [
  "console",
  "fuzzy-matcher",
+ "shell-words",
  "tempfile",
  "zeroize",
 ]
@@ -698,9 +705,9 @@ dependencies = [
 
 [[package]]
 name = "enum_dispatch"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb609da60cb562dcb49cd458d42d0d8501d2312aa56dd246911472f9422db017"
+checksum = "11f36e95862220b211a6e2aa5eca09b4fa391b13cd52ceb8035a24bf65a79de2"
 dependencies = [
  "once_cell",
  "proc-macro2",
@@ -954,6 +961,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "gio-sys"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9b693b8e39d042a95547fc258a7b07349b1f0b48f4b2fa3108ba3c51c0b5229"
+dependencies = [
+ "glib-sys 0.16.3",
+ "gobject-sys 0.16.3",
+ "libc",
+ "system-deps",
+ "winapi",
+]
+
+[[package]]
 name = "git2"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -977,9 +997,31 @@ dependencies = [
  "futures-core",
  "futures-executor",
  "futures-task",
- "glib-macros",
- "glib-sys",
- "gobject-sys",
+ "glib-macros 0.15.11",
+ "glib-sys 0.15.10",
+ "gobject-sys 0.15.10",
+ "libc",
+ "once_cell",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "glib"
+version = "0.16.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd4df61a866ed7259d6189b8bcb1464989a77f1d85d25d002279bbe9dd38b2f"
+dependencies = [
+ "bitflags",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-task",
+ "futures-util",
+ "gio-sys",
+ "glib-macros 0.16.3",
+ "glib-sys 0.16.3",
+ "gobject-sys 0.16.3",
  "libc",
  "once_cell",
  "smallvec",
@@ -994,7 +1036,22 @@ checksum = "25a68131a662b04931e71891fb14aaf65ee4b44d08e8abc10f49e77418c86c64"
 dependencies = [
  "anyhow",
  "heck",
- "proc-macro-crate 1.2.1",
+ "proc-macro-crate 1.3.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "glib-macros"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e084807350b01348b6d9dbabb724d1a0bb987f47a2c85de200e98e12e30733bf"
+dependencies = [
+ "anyhow",
+ "heck",
+ "proc-macro-crate 1.3.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -1012,12 +1069,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "glib-sys"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61a4f46316d06bfa33a7ac22df6f0524c8be58e3db2d9ca99ccb1f357b62a65"
+dependencies = [
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "gobject-sys"
 version = "0.15.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d57ce44246becd17153bd035ab4d32cfee096a657fc01f2231c9278378d1e0a"
 dependencies = [
- "glib-sys",
+ "glib-sys 0.15.10",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gobject-sys"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3520bb9c07ae2a12c7f2fbb24d4efc11231c8146a86956413fb1a79bb760a0f1"
+dependencies = [
+ "glib-sys 0.16.3",
  "libc",
  "system-deps",
 ]
@@ -1033,14 +1111,40 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "glib",
- "gstreamer-sys",
+ "glib 0.15.12",
+ "gstreamer-sys 0.18.0",
  "libc",
  "muldiv",
  "num-integer",
  "num-rational",
  "once_cell",
- "option-operations",
+ "option-operations 0.4.1",
+ "paste",
+ "pretty-hex",
+ "serde",
+ "serde_bytes",
+ "thiserror",
+]
+
+[[package]]
+name = "gstreamer"
+version = "0.19.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61af131b56332ec386a8ea538d961d0c6937054fb2771a9a505395f8471b7b0e"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "glib 0.16.7",
+ "gstreamer-sys 0.19.4",
+ "libc",
+ "muldiv",
+ "num-integer",
+ "num-rational",
+ "once_cell",
+ "option-operations 0.5.0",
  "paste",
  "pretty-hex",
  "serde",
@@ -1050,40 +1154,41 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-base"
-version = "0.18.0"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224f35f36582407caf58ded74854526beeecc23d0cf64b8d1c3e00584ed6863f"
+checksum = "a61a299f9ea2ca892b43e2e428b86c679875e95ba23f8ae06fd730308df630f0"
 dependencies = [
+ "atomic_refcell",
  "bitflags",
  "cfg-if",
- "glib",
- "gstreamer",
+ "glib 0.16.7",
+ "gstreamer 0.19.7",
  "gstreamer-base-sys",
  "libc",
 ]
 
 [[package]]
 name = "gstreamer-base-sys"
-version = "0.18.0"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a083493c3c340e71fa7c66eebda016e9fafc03eb1b4804cf9b2bad61994b078e"
+checksum = "dbc3c4476e1503ae245c89fbe20060c30ec6ade5f44620bcc402cbc70a3911a1"
 dependencies = [
- "glib-sys",
- "gobject-sys",
- "gstreamer-sys",
+ "glib-sys 0.16.3",
+ "gobject-sys 0.16.3",
+ "gstreamer-sys 0.19.4",
  "libc",
  "system-deps",
 ]
 
 [[package]]
 name = "gstreamer-player"
-version = "0.18.0"
+version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f14ee02352ba73cadebe640bfb33f12fe8d03cbcad816a102d55a0251fb99bb"
+checksum = "9d058cf1a5db88fdfdc370a3e7c88335cba2f238578a794e1f8e58d8f903835d"
 dependencies = [
  "bitflags",
- "glib",
- "gstreamer",
+ "glib 0.16.7",
+ "gstreamer 0.19.7",
  "gstreamer-player-sys",
  "gstreamer-video",
  "libc",
@@ -1092,13 +1197,13 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-player-sys"
-version = "0.18.0"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f9b674b39a4d0e18710f6e3d2b109f1793d8028ee4e39da3909b55b4529d399"
+checksum = "4725bb801f8c7976f93d3846eca66c8ababf263bafcca3c43a7b17f9f01fae19"
 dependencies = [
- "glib-sys",
- "gobject-sys",
- "gstreamer-sys",
+ "glib-sys 0.16.3",
+ "gobject-sys 0.16.3",
+ "gstreamer-sys 0.19.4",
  "gstreamer-video-sys",
  "libc",
  "system-deps",
@@ -1110,23 +1215,35 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3517a65d3c2e6f8905b456eba5d53bda158d664863aef960b44f651cb7d33e2"
 dependencies = [
- "glib-sys",
- "gobject-sys",
+ "glib-sys 0.15.10",
+ "gobject-sys 0.15.10",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gstreamer-sys"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "545f52ad8a480732cc4290fd65dfe42952c8ae374fe581831ba15981fedf18a4"
+dependencies = [
+ "glib-sys 0.16.3",
+ "gobject-sys 0.16.3",
  "libc",
  "system-deps",
 ]
 
 [[package]]
 name = "gstreamer-video"
-version = "0.18.7"
+version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9418adfc72dafa1ad9eb106527ce4804887d101027c4528ec28c7d29cc899519"
+checksum = "eb19dcbdd5436483e764318bef157070f192acc5b1199e85878723a9ce33d4e3"
 dependencies = [
  "bitflags",
  "cfg-if",
  "futures-channel",
- "glib",
- "gstreamer",
+ "glib 0.16.7",
+ "gstreamer 0.19.7",
  "gstreamer-base",
  "gstreamer-video-sys",
  "libc",
@@ -1135,14 +1252,14 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-video-sys"
-version = "0.18.3"
+version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33331b1675e73b5b000c796354278eca7fdde9327015971d9f41afe28b96e0dc"
+checksum = "7546bc798c898f2083330d81a7efff48f65a31b03873f410538032d26ec0cdc7"
 dependencies = [
- "glib-sys",
- "gobject-sys",
+ "glib-sys 0.16.3",
+ "gobject-sys 0.16.3",
  "gstreamer-base-sys",
- "gstreamer-sys",
+ "gstreamer-sys 0.19.4",
  "libc",
  "system-deps",
 ]
@@ -1268,7 +1385,7 @@ dependencies = [
  "enum-as-inner",
  "flume",
  "futures",
- "gstreamer",
+ "gstreamer 0.19.7",
  "gstreamer-player",
  "log",
  "md5",
@@ -1426,9 +1543,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.2"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4295cbb7573c16d310e99e713cf9e75101eb190ab31fccd35f2d2691b4352b19"
+checksum = "cef509aa9bc73864d6756f0d34d35504af3cf0844373afe9b8669a5b8005a729"
 dependencies = [
  "console",
  "number_prefix",
@@ -1463,9 +1580,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
+checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
 dependencies = [
  "libc",
  "windows-sys",
@@ -1562,9 +1679,9 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.13.4+1.4.2"
+version = "0.13.5+1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0fa6563431ede25f5cc7f6d803c6afbc1c5d3ad3d4925d12c882bf2b526f5d1"
+checksum = "51e5ea06c26926f1002dd553fded6cfcdc9784c1f60feeb58368b4d9b07b6dba"
 dependencies = [
  "cc",
  "libc",
@@ -1656,9 +1773,9 @@ dependencies = [
 
 [[package]]
 name = "matches"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "maybe-async"
@@ -1821,9 +1938,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a58d1d356c6597d08cde02c2f09d785b09e28711837b1ed667dc652c08a694"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1833,12 +1950,21 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.2"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5507769c4919c998e69e49c839d9dc6e693ede4cc4290d6ad8b41d4f09c548c"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom8"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1975,6 +2101,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-operations"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c26d27bb1aeab65138e4bf7666045169d1717febcc9ff870166be8348b223d0"
+dependencies = [
+ "paste",
+]
+
+[[package]]
 name = "ordered-stream"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2052,9 +2187,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4257b4a04d91f7e9e6290be5d3da4804dd5784fafde3a497d73eb2b4a158c30a"
+checksum = "4ab62d2fa33726dbe6321cc97ef96d8cde531e3eeaf858a058de53a8a6d40d8f"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -2062,9 +2197,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241cda393b0cdd65e62e07e12454f1f25d57017dcc514b1514cd3c4645e3a0a6"
+checksum = "8bf026e2d0581559db66d837fe5242320f525d85c76283c61f4d51a1238d65ea"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2072,9 +2207,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46b53634d8c8196302953c74d5352f33d0c512a9499bd2ce468fc9f4128fa27c"
+checksum = "2b27bd18aa01d91c8ed2b61ea23406a676b42d82609c6e2581fba42f0c15f17f"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2085,9 +2220,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef4f1332a8d4678b41966bb4cc1d0676880e84183a1ecc3f4b69f03e99c7a51"
+checksum = "9f02b677c1859756359fc9983c2e56a0237f18624a3789528804406b7e915e5d"
 dependencies = [
  "once_cell",
  "pest",
@@ -2190,13 +2325,12 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda0fc3b0fb7c975631757e14d9049da17374063edb6ebbcbc54d880d4fe94e9"
+checksum = "66618389e4ec1c7afe67d51a9bf34ff9236480f8d51e7489b7d5ab0303c13f34"
 dependencies = [
  "once_cell",
- "thiserror",
- "toml",
+ "toml_edit",
 ]
 
 [[package]]
@@ -2224,16 +2358,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
 dependencies = [
  "unicode-ident",
 ]
@@ -2286,7 +2414,7 @@ dependencies = [
  "enum-as-inner",
  "flume",
  "futures",
- "gstreamer",
+ "gstreamer 0.18.8",
  "insta",
  "log",
  "md5",
@@ -2424,11 +2552,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
+checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.0",
  "bytes",
  "cookie",
  "cookie_store",
@@ -2449,7 +2577,6 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "proc-macro-hack",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2461,6 +2588,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "winreg",
 ]
@@ -2565,9 +2693,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.27.0"
+version = "1.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c321ee4e17d2b7abe12b5d20c1231db708dd36185c8a21e9de5fed6da4dbe9"
+checksum = "7fe32e8c89834541077a5c5bbe5691aa69324361e27e6aeb3552a737db4a70c8"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -2589,9 +2717,9 @@ checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 
 [[package]]
 name = "rustix"
-version = "0.36.6"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
+checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
 dependencies = [
  "bitflags",
  "errno",
@@ -2603,9 +2731,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.7"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
 dependencies = [
  "log",
  "ring",
@@ -2703,9 +2831,9 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "security-framework"
-version = "2.7.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
+checksum = "7c4437699b6d34972de58652c68b98cb5b53a4199ab126db8e20ec8ded29a721"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -2716,9 +2844,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.6.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2819,6 +2947,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "signal-hook"
@@ -2926,9 +3060,9 @@ dependencies = [
 
 [[package]]
 name = "sqlformat"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87e292b4291f154971a43c3774364e2cbcaec599d3f5bf6fa9d122885dbc38a"
+checksum = "0c12bc9199d1db8234678b7051747c07f517cdcf019262d1847b94ec8b1aee3e"
 dependencies = [
  "itertools",
  "nom",
@@ -3121,9 +3255,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
@@ -3235,9 +3369,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.24.1"
+version = "1.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
+checksum = "597a12a59981d9e3c38d216785b0c37399f6e415e8d0712047620f189371b0bb"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3350,11 +3484,28 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4553f467ac8e3d374bc9a177a26801e5d0f9b211aa1673fb137a403afd1c9cf5"
+
+[[package]]
+name = "toml_edit"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "729bfd096e40da9c001f778f5cdecbd2957929a24e10e5883d9392220a751581"
+dependencies = [
+ "indexmap",
+ "nom8",
+ "toml_datetime",
 ]
 
 [[package]]
@@ -3476,9 +3627,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
 
 [[package]]
 name = "unicode-ident"
@@ -3705,6 +3856,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
+name = "wasm-streams"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bbae3363c08332cadccd13b67db371814cd214c2524020932f0804b8cf7c078"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3716,9 +3880,9 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e74f5ff7786c4c21f61ba8e30ea29c9745f06fca0a4a02d083b3c662583399e8"
+checksum = "769f1a8831de12cad7bd6f9693b15b1432d93a151557810f617f626af823acae"
 dependencies = [
  "core-foundation",
  "dirs",
@@ -3729,7 +3893,6 @@ dependencies = [
  "raw-window-handle",
  "url",
  "web-sys",
- "windows",
 ]
 
 [[package]]
@@ -3783,21 +3946,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04662ed0e3e5630dfa9b26e4cb823b817f1a9addda855d973a9458c236556244"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
 name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3814,45 +3962,45 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "winreg"
@@ -3914,7 +4062,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66492a2e90c0df7190583eccb8424aa12eb7ff06edea415a4fff6688fae18cf8"
 dependencies = [
- "proc-macro-crate 1.2.1",
+ "proc-macro-crate 1.3.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -3979,7 +4127,7 @@ version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fd4aafc0dee96ae7242a24249ce9babf21e1562822f03df650d4e68c20e41ed"
 dependencies = [
- "proc-macro-crate 1.2.1",
+ "proc-macro-crate 1.3.0",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,12 +107,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic_refcell"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "857253367827bd9d0fd973f0ef15506a96e79e41b0ad7aa691203a4e3214f6c8"
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1153,63 +1147,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gstreamer-base"
-version = "0.19.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61a299f9ea2ca892b43e2e428b86c679875e95ba23f8ae06fd730308df630f0"
-dependencies = [
- "atomic_refcell",
- "bitflags",
- "cfg-if",
- "glib 0.16.7",
- "gstreamer 0.19.7",
- "gstreamer-base-sys",
- "libc",
-]
-
-[[package]]
-name = "gstreamer-base-sys"
-version = "0.19.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc3c4476e1503ae245c89fbe20060c30ec6ade5f44620bcc402cbc70a3911a1"
-dependencies = [
- "glib-sys 0.16.3",
- "gobject-sys 0.16.3",
- "gstreamer-sys 0.19.4",
- "libc",
- "system-deps",
-]
-
-[[package]]
-name = "gstreamer-player"
-version = "0.19.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d058cf1a5db88fdfdc370a3e7c88335cba2f238578a794e1f8e58d8f903835d"
-dependencies = [
- "bitflags",
- "glib 0.16.7",
- "gstreamer 0.19.7",
- "gstreamer-player-sys",
- "gstreamer-video",
- "libc",
- "once_cell",
-]
-
-[[package]]
-name = "gstreamer-player-sys"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4725bb801f8c7976f93d3846eca66c8ababf263bafcca3c43a7b17f9f01fae19"
-dependencies = [
- "glib-sys 0.16.3",
- "gobject-sys 0.16.3",
- "gstreamer-sys 0.19.4",
- "gstreamer-video-sys",
- "libc",
- "system-deps",
-]
-
-[[package]]
 name = "gstreamer-sys"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1229,37 +1166,6 @@ checksum = "545f52ad8a480732cc4290fd65dfe42952c8ae374fe581831ba15981fedf18a4"
 dependencies = [
  "glib-sys 0.16.3",
  "gobject-sys 0.16.3",
- "libc",
- "system-deps",
-]
-
-[[package]]
-name = "gstreamer-video"
-version = "0.19.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb19dcbdd5436483e764318bef157070f192acc5b1199e85878723a9ce33d4e3"
-dependencies = [
- "bitflags",
- "cfg-if",
- "futures-channel",
- "glib 0.16.7",
- "gstreamer 0.19.7",
- "gstreamer-base",
- "gstreamer-video-sys",
- "libc",
- "once_cell",
-]
-
-[[package]]
-name = "gstreamer-video-sys"
-version = "0.19.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7546bc798c898f2083330d81a7efff48f65a31b03873f410538032d26ec0cdc7"
-dependencies = [
- "glib-sys 0.16.3",
- "gobject-sys 0.16.3",
- "gstreamer-base-sys",
- "gstreamer-sys 0.19.4",
  "libc",
  "system-deps",
 ]
@@ -1386,7 +1292,6 @@ dependencies = [
  "flume",
  "futures",
  "gstreamer 0.19.7",
- "gstreamer-player",
  "log",
  "md5",
  "pretty_env_logger",
@@ -1403,7 +1308,6 @@ dependencies = [
  "tui",
  "url",
  "zbus",
- "zerocopy",
 ]
 
 [[package]]
@@ -1865,15 +1769,6 @@ dependencies = [
  "safemem",
  "tempfile",
  "twoway",
-]
-
-[[package]]
-name = "nanoid"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
-dependencies = [
- "rand",
 ]
 
 [[package]]
@@ -2408,17 +2303,12 @@ version = "0.1.0"
 dependencies = [
  "base64 0.13.1",
  "bincode",
- "byteorder",
  "chrono",
  "clap",
- "enum-as-inner",
- "flume",
- "futures",
  "gstreamer 0.18.8",
  "insta",
  "log",
  "md5",
- "nanoid",
  "pretty_env_logger",
  "regex",
  "reqwest",
@@ -2429,7 +2319,6 @@ dependencies = [
  "tokio-test",
  "url",
  "util",
- "zerocopy",
 ]
 
 [[package]]
@@ -4078,27 +3967,6 @@ dependencies = [
  "serde",
  "static_assertions",
  "zvariant",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332f188cc1bcf1fe1064b8c58d150f497e697f49774aa846f2dc949d9a25f236"
-dependencies = [
- "byteorder",
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6505e6815af7de1746a08f69c69606bb45695a17149517680f3b2149713b19a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/hifirs/Cargo.toml
+++ b/hifirs/Cargo.toml
@@ -18,7 +18,6 @@ enum-as-inner = "0.5"
 flume = "0.10"
 futures = "0.3"
 gstreamer = { version = "0.19", features = ["serde"] }
-gstreamer-player = "0.19"
 log = "0.4"
 md5 = "0.7.0"
 pretty_env_logger = "0.4"
@@ -35,4 +34,3 @@ tokio-stream = "0.1"
 tui = { version = "0.19", default-features = false, features = ["termion"] }
 url = "2.2"
 zbus = { version = "3", default-features = false, features = ["tokio"] }
-zerocopy = "0.6"

--- a/hifirs/Cargo.toml
+++ b/hifirs/Cargo.toml
@@ -4,13 +4,13 @@ name = "hifi-rs"
 version = "0.1.0"
 
 [dependencies]
+async-trait = "0.1"
 base64 = "0.13"
 bincode = "1.3"
 byteorder = "1.4"
 chrono = "0.4"
 clap = { version = "4", features = ["derive", "env"] }
 comfy-table = "6.0"
-crossbeam = "0.8"
 ctrlc = { version = "3.0", features = ["termination"] }
 dialoguer = { version = "0.10.1", features = ["fuzzy-select"] }
 dirs = "4.0"
@@ -26,12 +26,11 @@ qobuz-client = { path = "../qobuz-client" }
 regex = "1.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-sled = { version = "0.34", features = ["compression"] }
 snafu = "0.7"
 sqlx = { version = "0.6", features = [ "runtime-tokio-rustls", "sqlite", "all-types", "default", "offline" ] }
 termion = "1.5"
 textwrap = "0.15"
-tokio = { version = "1.0", features = ["full"]} 
+tokio = { version = "1.0", features = ["full"]}
 tokio-stream = "0.1"
 tui = { version = "0.19", default-features = false, features = ["termion"] }
 url = "2.2"

--- a/hifirs/Cargo.toml
+++ b/hifirs/Cargo.toml
@@ -17,8 +17,8 @@ dirs = "4.0"
 enum-as-inner = "0.5"
 flume = "0.10"
 futures = "0.3"
-gstreamer = { version = "0.18", features = ["ser_de"] }
-gstreamer-player = "0.18"
+gstreamer = { version = "0.19", features = ["serde"] }
+gstreamer-player = "0.19"
 log = "0.4"
 md5 = "0.7.0"
 pretty_env_logger = "0.4"

--- a/hifirs/src/cli.rs
+++ b/hifirs/src/cli.rs
@@ -182,28 +182,30 @@ pub async fn run() -> Result<(), Error> {
     // CLI COMMANDS
     match cli.command {
         Commands::Resume { no_tui } => {
-            let player = player::new(data.clone(), client.clone(), true).await;
+            let player = player::new(client.clone(), true).await;
 
             player.play();
 
             if no_tui {
                 wait!(data);
             } else {
-                let mut tui = ui::new(data.clone(), player.controls(), client, None, None).await?;
+                let mut tui =
+                    ui::new(player.state(), player.controls(), client, None, None).await?;
                 tui.event_loop().await?;
             }
 
             Ok(())
         }
         Commands::Play { uri, no_tui } => {
-            let mut player = player::new(data.clone(), client.clone(), true).await;
+            let player = player::new(client.clone(), true).await;
 
             player.play_uri(uri, Some(client.quality())).await;
 
             if no_tui {
                 wait!(data);
             } else {
-                let mut tui = ui::new(data.clone(), player.controls(), client, None, None).await?;
+                let mut tui =
+                    ui::new(player.state(), player.controls(), client, None, None).await?;
                 tui.event_loop().await?;
             }
             Ok(())
@@ -234,13 +236,13 @@ pub async fn run() -> Result<(), Error> {
             if no_tui {
                 output!(results, output_format);
             } else {
-                let player = player::new(data.clone(), client.clone(), true).await;
+                let player = player::new(client.clone(), true).await;
 
                 if no_tui {
                     wait!(data);
                 } else {
                     let mut tui = ui::new(
-                        data.clone(),
+                        player.state(),
                         player.controls(),
                         client,
                         Some(results),
@@ -265,13 +267,13 @@ pub async fn run() -> Result<(), Error> {
             if no_tui {
                 output!(results, output_format);
             } else {
-                let player = player::new(data.clone(), client.clone(), true).await;
+                let player = player::new(client.clone(), true).await;
 
                 if no_tui {
                     wait!(data);
                 } else {
                     let mut tui = ui::new(
-                        data.clone(),
+                        player.state(),
                         player.controls(),
                         client,
                         Some(results),
@@ -292,14 +294,17 @@ pub async fn run() -> Result<(), Error> {
             if no_tui {
                 println!("nothing to show");
             } else {
-                let player = player::new(data.clone(), client.clone(), true).await;
+                let player = player::new(client.clone(), true).await;
 
                 if no_tui {
                     wait!(data);
                 } else {
                     let mut tui =
-                        ui::new(data.clone(), player.controls(), client, None, None).await?;
-                    switch_screen!(data, ActiveScreen::Playlists);
+                        ui::new(player.state(), player.controls(), client, None, None).await?;
+
+                    let state = player.state();
+
+                    switch_screen!(state.write().await, ActiveScreen::Playlists);
                     tui.event_loop().await?;
                 }
             }
@@ -319,7 +324,7 @@ pub async fn run() -> Result<(), Error> {
             quality,
             no_tui,
         } => {
-            let mut player = player::new(data.clone(), client.clone(), false).await;
+            let player = player::new(client.clone(), false).await;
 
             let track = client.track(track_id).await?;
 
@@ -328,7 +333,8 @@ pub async fn run() -> Result<(), Error> {
             if no_tui {
                 wait!(data);
             } else {
-                let mut tui = ui::new(data, player.controls(), client, None, None).await?;
+                let mut tui =
+                    ui::new(player.state(), player.controls(), client, None, None).await?;
                 tui.event_loop().await?;
             }
 
@@ -347,14 +353,18 @@ pub async fn run() -> Result<(), Error> {
                 client.quality()
             };
 
-            let mut player = player::new(data.clone(), client.clone(), false).await;
+            let player = player::new(client.clone(), false).await;
             player.play_album(album, Some(quality)).await;
 
             if no_tui {
                 wait!(data);
             } else {
-                let mut tui = ui::new(data.clone(), player.controls(), client, None, None).await?;
-                switch_screen!(data, ActiveScreen::NowPlaying);
+                let mut tui =
+                    ui::new(player.state(), player.controls(), client, None, None).await?;
+
+                let state = player.state();
+                switch_screen!(state.write().await, ActiveScreen::NowPlaying);
+
                 tui.event_loop().await?;
             }
 

--- a/hifirs/src/cli.rs
+++ b/hifirs/src/cli.rs
@@ -304,7 +304,7 @@ pub async fn run() -> Result<(), Error> {
 
                     let state = player.state();
 
-                    switch_screen!(state.write().await, ActiveScreen::Playlists);
+                    switch_screen!(state.lock().await, ActiveScreen::Playlists);
                     tui.event_loop().await?;
                 }
             }
@@ -363,7 +363,7 @@ pub async fn run() -> Result<(), Error> {
                     ui::new(player.state(), player.controls(), client, None, None).await?;
 
                 let state = player.state();
-                switch_screen!(state.write().await, ActiveScreen::NowPlaying);
+                switch_screen!(state.lock().await, ActiveScreen::NowPlaying);
 
                 tui.event_loop().await?;
             }

--- a/hifirs/src/cli.rs
+++ b/hifirs/src/cli.rs
@@ -96,7 +96,7 @@ enum Commands {
         no_tui: bool,
     },
     /// Retreive information about a specific playlist.
-    Playlist { playlist_id: String },
+    Playlist { playlist_id: i64 },
     /// Reset the player state
     Reset,
     /// Set configuration options

--- a/hifirs/src/cli.rs
+++ b/hifirs/src/cli.rs
@@ -316,7 +316,7 @@ pub async fn run() -> Result<(), Error> {
             let json =
                 serde_json::to_string(&results).expect("failed to convert results to string");
 
-            print!("{}", json);
+            print!("{json}");
             Ok(())
         }
         Commands::StreamTrack {

--- a/hifirs/src/mpris.rs
+++ b/hifirs/src/mpris.rs
@@ -194,11 +194,10 @@ impl MprisTrackList {
     ) -> Vec<HashMap<&'static str, zvariant::Value>> {
         if let Some(playlist) = self.controls.remaining_tracks().await {
             playlist
-                .vec()
-                .iter()
+                .into_iter()
                 .filter_map(|i| {
                     if tracks.contains(&i.track.id.to_string()) {
-                        Some(track_to_meta(i.clone()))
+                        Some(track_to_meta(i))
                     } else {
                         None
                     }
@@ -223,7 +222,6 @@ impl MprisTrackList {
     async fn tracks(&self) -> Vec<String> {
         if let Some(playlist) = self.controls.remaining_tracks().await {
             playlist
-                .vec()
                 .iter()
                 .map(|i| i.track.id.to_string())
                 .collect::<Vec<String>>()

--- a/hifirs/src/mpris.rs
+++ b/hifirs/src/mpris.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::player::Controls;
+use crate::{player::Controls, state::app::SafePlayerState};
 use gstreamer::ClockTime;
 use qobuz_client::client::track::TrackListTrack;
 use zbus::{dbus_interface, fdo::Result, zvariant, Connection, ConnectionBuilder, SignalContext};
@@ -10,14 +10,15 @@ pub struct Mpris {
     controls: Controls,
 }
 
-pub async fn init(controls: Controls) -> Connection {
+pub async fn init(state: SafePlayerState, controls: Controls) -> Connection {
     let mpris = Mpris {
         controls: controls.clone(),
     };
     let mpris_player = MprisPlayer {
         controls: controls.clone(),
+        state: state.clone(),
     };
-    let mpris_tracklist = MprisTrackList { controls };
+    let mpris_tracklist = MprisTrackList { controls, state };
 
     ConnectionBuilder::session()
         .unwrap()
@@ -74,6 +75,7 @@ impl Mpris {
 #[derive(Debug)]
 pub struct MprisPlayer {
     controls: Controls,
+    state: SafePlayerState,
 }
 
 #[dbus_interface(name = "org.mpris.MediaPlayer2.Player")]
@@ -101,11 +103,7 @@ impl MprisPlayer {
     }
     #[dbus_interface(property, name = "PlaybackStatus")]
     async fn playback_status(&self) -> &'static str {
-        if let Some(status) = self.controls.status().await {
-            status.as_str()
-        } else {
-            ""
-        }
+        self.state.lock().await.status().as_str()
     }
     #[dbus_interface(property, name = "LoopStatus")]
     fn loop_status(&self) -> &'static str {
@@ -121,7 +119,8 @@ impl MprisPlayer {
     }
     #[dbus_interface(property, name = "Metadata")]
     async fn metadata(&self) -> HashMap<&'static str, zvariant::Value> {
-        if let Some(next_up) = self.controls.currently_playing_track().await {
+        debug!("dbus metadata");
+        if let Some(next_up) = self.state.lock().await.current_track() {
             track_to_meta(next_up)
         } else {
             HashMap::new()
@@ -133,14 +132,18 @@ impl MprisPlayer {
     }
     #[dbus_interface(property, name = "Position")]
     async fn position(&self) -> i64 {
-        if let Some(position) = self.controls.position().await {
-            position.inner_clocktime().useconds() as i64
-        } else {
-            0
-        }
+        self.state
+            .lock()
+            .await
+            .position()
+            .inner_clocktime()
+            .useconds() as i64
     }
     #[dbus_interface(signal, name = "Seeked")]
-    pub async fn seeked(ctxt: &SignalContext<'_>, message: i64) -> zbus::Result<()>;
+    pub async fn seeked(
+        #[zbus(signal_context)] ctxt: &SignalContext<'_>,
+        message: i64,
+    ) -> zbus::Result<()>;
     // #[dbus_interface(property)]
     // async fn set_position(&self, current: String, position: i64) {
     //     if let Some(next_up) = self.controls.currently_playing_track().await {
@@ -184,6 +187,7 @@ impl MprisPlayer {
 #[derive(Debug)]
 pub struct MprisTrackList {
     controls: Controls,
+    state: SafePlayerState,
 }
 
 #[dbus_interface(name = "org.mpris.MediaPlayer2.TrackList")]
@@ -192,20 +196,19 @@ impl MprisTrackList {
         &self,
         tracks: Vec<String>,
     ) -> Vec<HashMap<&'static str, zvariant::Value>> {
-        if let Some(playlist) = self.controls.remaining_tracks().await {
-            playlist
-                .into_iter()
-                .filter_map(|i| {
-                    if tracks.contains(&i.track.id.to_string()) {
-                        Some(track_to_meta(i))
-                    } else {
-                        None
-                    }
-                })
-                .collect::<Vec<HashMap<&'static str, zvariant::Value>>>()
-        } else {
-            vec![]
-        }
+        self.state
+            .lock()
+            .await
+            .unplayed_tracks()
+            .into_iter()
+            .filter_map(|i| {
+                if tracks.contains(&i.track.id.to_string()) {
+                    Some(track_to_meta(i.clone()))
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<HashMap<&'static str, zvariant::Value>>>()
     }
     async fn go_to(&self, track_id: String) {
         if let Ok(id) = track_id.parse::<usize>() {
@@ -214,20 +217,19 @@ impl MprisTrackList {
     }
     #[dbus_interface(signal, name = "Seeked")]
     pub async fn track_list_replaced(
-        ctxt: &SignalContext<'_>,
+        #[zbus(signal_context)] ctxt: &SignalContext<'_>,
         tracks: Vec<String>,
         current: String,
     ) -> zbus::Result<()>;
     #[dbus_interface(property, name = "Tracks")]
     async fn tracks(&self) -> Vec<String> {
-        if let Some(playlist) = self.controls.remaining_tracks().await {
-            playlist
-                .iter()
-                .map(|i| i.track.id.to_string())
-                .collect::<Vec<String>>()
-        } else {
-            vec![]
-        }
+        self.state
+            .lock()
+            .await
+            .unplayed_tracks()
+            .iter()
+            .map(|i| i.track.id.to_string())
+            .collect::<Vec<String>>()
     }
     #[dbus_interface(property, name = "CanEditTracks")]
     async fn can_edit_tracks(&self) -> bool {
@@ -264,9 +266,7 @@ fn track_to_meta(
     );
 
     if let Some(album) = playlist_track.album {
-        if let Some(thumb) = album.image.thumbnail {
-            meta.insert("mpris:artUrl", zvariant::Value::new(thumb));
-        }
+        meta.insert("mpris:artUrl", zvariant::Value::new(album.image.large));
         meta.insert("xesam:album", zvariant::Value::new(album.title));
         meta.insert(
             "xesam:albumArtist",

--- a/hifirs/src/player.rs
+++ b/hifirs/src/player.rs
@@ -316,6 +316,8 @@ impl Player {
         self.ready();
 
         let mut state = self.state.lock().await;
+        state.reset_player();
+
         if let Some(mut next_track_to_play) = state.skip_track(num, direction.clone()).await {
             if let Some(track_url) = next_track_to_play.track_url {
                 debug!("skipping {direction} to next track");

--- a/hifirs/src/player.rs
+++ b/hifirs/src/player.rs
@@ -70,7 +70,9 @@ pub struct Player {
 pub async fn new(client: Client, _resume: bool) -> Player {
     gst::init().expect("Couldn't initialize Gstreamer");
     let state = SafePlayerState::default();
-    let playbin = gst::ElementFactory::make("playbin", None).expect("failed to create gst element");
+    let playbin = gst::ElementFactory::make("playbin")
+        .build()
+        .expect("failed to create gst element");
     let controls = Controls::new(state.clone());
 
     let connection = mpris::init(controls.clone()).await;

--- a/hifirs/src/player.rs
+++ b/hifirs/src/player.rs
@@ -45,14 +45,27 @@ pub enum Action {
     Previous,
     Stop,
     Quit,
-    SkipTo { num: usize },
-    SkipToById { track_id: usize },
+    SkipTo {
+        num: usize,
+        direction: SkipDirection,
+    },
+    SkipToById {
+        track_id: usize,
+    },
     JumpForward,
     JumpBackward,
-    PlayAlbum { album_id: String },
-    PlayTrack { track_id: i32 },
-    PlayUri { uri: String },
-    PlayPlaylist { playlist_id: i64 },
+    PlayAlbum {
+        album_id: String,
+    },
+    PlayTrack {
+        track_id: i32,
+    },
+    PlayUri {
+        uri: String,
+    },
+    PlayPlaylist {
+        playlist_id: i64,
+    },
 }
 
 /// A player handles playing media to a device.
@@ -278,7 +291,7 @@ impl Player {
             }
         }
     }
-    /// Skip forward to the next track in the playlist.
+    /// Skip to the next, previous or specific track in the playlist.
     pub async fn skip(&self, direction: SkipDirection, num: Option<usize>) -> Result<()> {
         // If the track is greater than 1 second into playing,
         // then we just want to go back to the beginning.
@@ -560,7 +573,7 @@ impl Player {
                             }
                         },
                         Action::Quit => self.state.lock().await.quit(),
-                        Action::SkipTo { num } => self.skip_to(num).await.expect("failed to skip to track"),
+                        Action::SkipTo { num, direction } => self.skip(direction, Some(num)).await.expect("failed to skip to track"),
                         Action::SkipToById { track_id } => self.skip_to_by_id(track_id).await.expect("failed to skip to track"),
                     }
                 }
@@ -842,8 +855,8 @@ impl Controls {
     pub async fn previous(&self) {
         action!(self, Action::Previous);
     }
-    pub async fn skip_to(&self, num: usize) {
-        action!(self, Action::SkipTo { num });
+    pub async fn skip_to(&self, num: usize, direction: SkipDirection) {
+        action!(self, Action::SkipTo { num, direction });
     }
     pub async fn skip_to_by_id(&self, track_id: usize) {
         action!(self, Action::SkipToById { track_id })

--- a/hifirs/src/qobuz/track.rs
+++ b/hifirs/src/qobuz/track.rs
@@ -1,7 +1,7 @@
 use crate::ui::components::{ColumnWidth, Row, TableHeaders, TableRow, TableRows, TableWidths};
 use qobuz_client::client::{
     playlist::TrackListTracks,
-    track::{Track, TrackListTrack, Tracks},
+    track::{Track, TrackListTrack, TrackStatus, Tracks},
 };
 
 impl TableRow for Track {
@@ -40,7 +40,13 @@ impl TableWidths for Track {
 
 impl TableRow for TrackListTrack {
     fn row(&self) -> Row {
-        Row::new(self.columns(), Track::widths())
+        let mut row = Row::new(self.columns(), Track::widths());
+
+        if self.status == TrackStatus::Played {
+            row.set_dim(true);
+        }
+
+        row
     }
 }
 

--- a/hifirs/src/sql/db.rs
+++ b/hifirs/src/sql/db.rs
@@ -32,6 +32,7 @@ pub async fn new() -> Database {
     };
 
     let options = SqliteConnectOptions::new()
+        .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal)
         .filename(database_url)
         .create_if_missing(true);
 

--- a/hifirs/src/state/app.rs
+++ b/hifirs/src/state/app.rs
@@ -103,8 +103,8 @@ impl PlayerState {
         self.duration_remaining = remaining;
     }
 
-    pub fn set_duration(&mut self, remaining: ClockValue) {
-        self.duration = remaining;
+    pub fn set_duration(&mut self, duration: ClockValue) {
+        self.duration = duration;
     }
 
     pub fn duration(&self) -> ClockValue {

--- a/hifirs/src/state/app.rs
+++ b/hifirs/src/state/app.rs
@@ -1,7 +1,12 @@
-use super::{HifiDB, StateTree};
+use crate::state::{ActiveScreen, ClockValue, FloatValue, StatusValue, TrackListValue};
+use crate::ui::components::{Row, TableRows};
+use qobuz_client::client::album::Album;
+use qobuz_client::client::playlist::Playlist;
+use qobuz_client::client::track::{TrackListTrack, TrackStatus};
 use snafu::prelude::*;
-use std::path::PathBuf;
-use tokio::sync::broadcast::{Receiver, Sender};
+use std::sync::Arc;
+use tokio::sync::broadcast::{Receiver as BroadcastReceiver, Sender as BroadcastSender};
+use tokio::sync::RwLock;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -18,6 +23,196 @@ pub enum Error {
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[derive(Debug, Clone)]
+pub struct PlayerState {
+    current_track: Option<TrackListTrack>,
+    tracklist: TrackListValue,
+    current_progress: FloatValue,
+    duration_remaining: ClockValue,
+    duration: ClockValue,
+    position: ClockValue,
+    status: StatusValue,
+    is_buffering: bool,
+    resume: bool,
+    active_screen: ActiveScreen,
+    quit_sender: BroadcastSender<bool>,
+}
+
+pub type SafePlayerState = Arc<RwLock<PlayerState>>;
+
+impl PlayerState {
+    pub fn set_active_screen(&mut self, screen: ActiveScreen) {
+        self.active_screen = screen;
+    }
+
+    pub fn active_screen(&self) -> ActiveScreen {
+        self.active_screen.clone()
+    }
+
+    pub fn set_status(&mut self, status: StatusValue) {
+        self.status = status;
+    }
+
+    pub fn status(&self) -> StatusValue {
+        self.status.clone()
+    }
+
+    pub fn set_current_track(&mut self, track: TrackListTrack) {
+        self.current_track = Some(track);
+    }
+
+    pub fn set_position(&mut self, position: ClockValue) {
+        self.position = position;
+    }
+
+    pub fn position(&self) -> ClockValue {
+        self.position.clone()
+    }
+
+    pub fn set_buffering(&mut self, buffering: bool) {
+        self.is_buffering = buffering;
+    }
+
+    pub fn buffering(&self) -> bool {
+        self.is_buffering
+    }
+
+    pub fn set_resume(&mut self, resume: bool) {
+        self.resume = resume;
+    }
+
+    pub fn set_current_progress(&mut self, progress: FloatValue) {
+        self.current_progress = progress;
+    }
+
+    pub fn progress(&self) -> FloatValue {
+        self.current_progress.clone()
+    }
+
+    pub fn set_duration_remaining(&mut self, remaining: ClockValue) {
+        self.duration_remaining = remaining;
+    }
+
+    pub fn set_duration(&mut self, remaining: ClockValue) {
+        self.duration = remaining;
+    }
+
+    pub fn duration(&self) -> ClockValue {
+        self.duration.clone()
+    }
+
+    pub fn current_track(&self) -> Option<TrackListTrack> {
+        self.current_track.clone()
+    }
+
+    pub fn unplayed_tracks(&self) -> Vec<&TrackListTrack> {
+        self.tracklist.unplayed_tracks()
+    }
+
+    pub fn played_tracks(&self) -> Vec<&TrackListTrack> {
+        self.tracklist.played_tracks()
+    }
+
+    pub fn album(&self) -> Option<&Album> {
+        self.tracklist.get_album()
+    }
+
+    pub fn playlist(&self) -> Option<&Playlist> {
+        self.tracklist.get_playlist()
+    }
+
+    pub fn current_track_index(&self) -> Option<usize> {
+        self.current_track.as_ref().map(|track| track.index)
+    }
+
+    pub fn replace_list(&mut self, tracklist: TrackListValue) {
+        debug!("replacing tracklist");
+        self.tracklist = tracklist;
+    }
+
+    pub fn track_index(&self, track_id: usize) -> Option<usize> {
+        if let Some(track) = self.tracklist.find_track(track_id) {
+            Some(track.index)
+        } else {
+            None
+        }
+    }
+
+    pub fn set_track_status(&mut self, track_id: usize, status: TrackStatus) {
+        self.tracklist.set_track_status(track_id, status);
+    }
+
+    pub fn rows(&self) -> Vec<Row> {
+        self.tracklist.rows()
+    }
+
+    pub fn next_track(&mut self, num: Option<usize>) -> Option<TrackListTrack> {
+        if let Some(next_track) = if let Some(current) = &self.current_track {
+            self.tracklist
+                .set_track_status(current.track.id as usize, TrackStatus::Played);
+
+            if let Some(n) = num {
+                self.tracklist.find_track_by_index(n)
+            } else {
+                self.tracklist.find_track_by_index(current.index + 1)
+            }
+        } else {
+            self.tracklist.queue.front().cloned()
+        } {
+            self.tracklist
+                .set_track_status(next_track.track.id as usize, TrackStatus::Playing);
+
+            self.current_track = Some(next_track.clone());
+            Some(next_track)
+        } else {
+            None
+        }
+    }
+
+    pub fn quitter(&self) -> BroadcastReceiver<bool> {
+        self.quit_sender.subscribe()
+    }
+
+    pub fn quit(&self) {
+        self.quit_sender
+            .send(true)
+            .expect("failed to send quit message");
+    }
+
+    pub fn reset(&mut self) {
+        self.tracklist.clear();
+        self.current_track = None;
+        self.current_progress = FloatValue(0.0);
+        self.duration_remaining = ClockValue::default();
+        self.duration = ClockValue::default();
+        self.position = ClockValue::default();
+        self.status = gstreamer::State::Null.into();
+        self.is_buffering = false;
+        self.resume = false;
+    }
+}
+
+impl Default for PlayerState {
+    fn default() -> Self {
+        let tracklist = TrackListValue::new(None);
+        let (quit_sender, _) = tokio::sync::broadcast::channel::<bool>(1);
+
+        Self {
+            current_track: None,
+            tracklist,
+            duration_remaining: ClockValue::default(),
+            duration: ClockValue::default(),
+            position: ClockValue::default(),
+            status: StatusValue(gstreamer::State::Null),
+            current_progress: FloatValue(0.0),
+            is_buffering: false,
+            resume: false,
+            active_screen: ActiveScreen::NowPlaying,
+            quit_sender,
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub enum StateKey {
@@ -98,76 +293,5 @@ impl PlayerKey {
             PlayerKey::Progress => "progress",
             PlayerKey::Status => "status",
         }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct AppState {
-    pub app: StateTree,
-    pub player: StateTree,
-    pub config: StateTree,
-    quit_sender: Sender<bool>,
-}
-
-pub fn new(base_dir: PathBuf) -> Result<AppState> {
-    let mut db_dir = base_dir;
-    db_dir.push("database");
-
-    let db = match sled::Config::default()
-        .path(db_dir)
-        .use_compression(true)
-        .compression_factor(10)
-        .mode(sled::Mode::LowSpace)
-        .print_profile_on_drop(false)
-        .flush_every_ms(Some(2500))
-        .open()
-    {
-        Ok(db) => HifiDB(db),
-        Err(err) => match err {
-            sled::Error::CollectionNotFound(e) => {
-                println!("ERROR: {:?}", e);
-                std::process::exit(1);
-            }
-            sled::Error::Unsupported(e) => {
-                println!("ERROR: {}", e);
-                std::process::exit(1);
-            }
-            sled::Error::ReportableBug(_) => {
-                println!("ERROR: There is a bug in the database. :(");
-                std::process::exit(1);
-            }
-            sled::Error::Io(_) => {
-                println!("The database is in use. Is another session running?");
-                std::process::exit(1);
-            }
-            sled::Error::Corruption { at, bt: _ } => {
-                println!("ERROR: Databast corruption at {}", at.unwrap(),);
-                std::process::exit(1);
-            }
-        },
-    };
-
-    // Quit channel
-    let (quit_sender, _) = tokio::sync::broadcast::channel::<bool>(1);
-
-    warn!("db was recovered: {}", db.0.was_recovered());
-
-    Ok(AppState {
-        app: db.open_tree("app"),
-        config: db.open_tree("config"),
-        player: db.open_tree("player"),
-        quit_sender,
-    })
-}
-
-impl AppState {
-    pub fn quitter(&self) -> Receiver<bool> {
-        self.quit_sender.subscribe()
-    }
-
-    pub fn quit(&self) {
-        self.quit_sender
-            .send(true)
-            .expect("failed to send quit message");
     }
 }

--- a/hifirs/src/state/app.rs
+++ b/hifirs/src/state/app.rs
@@ -181,6 +181,7 @@ impl PlayerState {
         direction: SkipDirection,
     ) -> Option<TrackListTrack> {
         let next_track_index = if let Some(i) = index {
+            debug!("received a track index, using that {i}");
             i
         } else if let Some(current_track_index) = self.current_track_index() {
             if direction == SkipDirection::Forward {

--- a/hifirs/src/ui/components/mod.rs
+++ b/hifirs/src/ui/components/mod.rs
@@ -75,7 +75,7 @@ where
 }
 
 #[allow(unused)]
-pub fn list<'t, B>(f: &mut Frame<B>, list: &'t mut List<'_>, title: &str, area: Rect)
+pub fn list<B>(f: &mut Frame<B>, list: &'_ mut List<'_>, title: &str, area: Rect)
 where
     B: Backend,
 {
@@ -96,7 +96,7 @@ where
     f.render_stateful_widget(term_list, layout[0], &mut list.state);
 }
 
-pub fn table<'r, B>(f: &mut Frame<B>, table: &'r mut Table, title: &str, area: Rect)
+pub fn table<B>(f: &mut Frame<B>, table: &'_ mut Table, title: &str, area: Rect)
 where
     B: Backend,
 {
@@ -132,7 +132,7 @@ where
         .iter()
         .cloned()
         .map(|t| {
-            let text = format!("{:^padding$}", t);
+            let text = format!("{t:^padding$}");
             Spans::from(text)
         })
         .collect();

--- a/hifirs/src/ui/components/player.rs
+++ b/hifirs/src/ui/components/player.rs
@@ -93,7 +93,7 @@ pub(crate) fn current_track<B>(
         current_track_text.insert(0, Spans::from(""));
     }
 
-    if let Some(album) = playlist_track.album {
+    if let Some(album) = &playlist_track.album {
         let release_year =
             chrono::NaiveDate::parse_from_str(&album.release_date_original, "%Y-%m-%d")
                 .unwrap()
@@ -105,9 +105,15 @@ pub(crate) fn current_track<B>(
         .wrap(Wrap { trim: false })
         .block(Block::default().style(Style::default().bg(Color::Indexed(237))));
 
+    let index = if playlist_track.album.is_some() {
+        playlist_track.track.track_number as usize
+    } else {
+        playlist_track.index
+    };
+
     let track_number_text = vec![
         Spans::from(""),
-        Spans::from(format!("{:02}", playlist_track.index)),
+        Spans::from(format!("{:02}", index)),
         Spans::from("of"),
         Spans::from(format!("{:02}", playlist_track.total)),
         Spans::from(""),

--- a/hifirs/src/ui/components/player.rs
+++ b/hifirs/src/ui/components/player.rs
@@ -30,7 +30,7 @@ pub(crate) fn progress<B>(
         };
 
         let progress = Gauge::default()
-            .label(format!("{} / {}", position, duration))
+            .label(format!("{position} / {duration}"))
             .use_unicode(true)
             .block(Block::default().style(Style::default().bg(Color::Indexed(236))))
             .gauge_style(
@@ -113,7 +113,7 @@ pub(crate) fn current_track<B>(
 
     let track_number_text = vec![
         Spans::from(""),
-        Spans::from(format!("{:02}", index)),
+        Spans::from(format!("{index:02}")),
         Spans::from("of"),
         Spans::from(format!("{:02}", playlist_track.total)),
         Spans::from(""),

--- a/hifirs/src/ui/components/player.rs
+++ b/hifirs/src/ui/components/player.rs
@@ -20,7 +20,14 @@ pub(crate) fn progress<B>(
 ) where
     B: Backend,
 {
-    if duration.inner_clocktime() > ClockTime::default() {
+    if is_buffering {
+        let text = "BUFFERING";
+        let loading = Paragraph::new(text)
+            .alignment(Alignment::Center)
+            .style(Style::default().bg(Color::Indexed(236)));
+
+        f.render_widget(loading, area);
+    } else if duration.inner_clocktime() > ClockTime::default() {
         let position = position.to_string().as_str()[3..7].to_string();
         let duration = duration.to_string().as_str()[3..7].to_string();
         let prog = if progress >= FloatValue(0.0) {
@@ -42,7 +49,7 @@ pub(crate) fn progress<B>(
             .ratio(prog.into());
         f.render_widget(progress, area);
     } else {
-        let text = if is_buffering { "BUFFERING" } else { "LOADING" };
+        let text = "LOADING";
         let loading = Paragraph::new(text)
             .alignment(Alignment::Center)
             .style(Style::default().bg(Color::Indexed(236)));

--- a/hifirs/src/ui/components/player.rs
+++ b/hifirs/src/ui/components/player.rs
@@ -14,6 +14,7 @@ pub(crate) fn progress<B>(
     position: ClockValue,
     duration: ClockValue,
     progress: FloatValue,
+    is_buffering: bool,
     f: &mut Frame<B>,
     area: Rect,
 ) where
@@ -41,7 +42,8 @@ pub(crate) fn progress<B>(
             .ratio(prog.into());
         f.render_widget(progress, area);
     } else {
-        let loading = Paragraph::new("LOADING")
+        let text = if is_buffering { "BUFFERING" } else { "LOADING" };
+        let loading = Paragraph::new(text)
             .alignment(Alignment::Center)
             .style(Style::default().bg(Color::Indexed(236)));
 

--- a/hifirs/src/ui/mod.rs
+++ b/hifirs/src/ui/mod.rs
@@ -257,11 +257,10 @@ impl Tui {
                     }
                 }
                 Key::Ctrl('c') | Key::Ctrl('q') => {
-                    if let Some(status) = self.controls.status().await {
-                        if status == GstState::Playing.into() {
-                            self.controls.pause().await;
-                            std::thread::sleep(Duration::from_millis(500));
-                        }
+                    let status = self.state.lock().await.status();
+                    if status == GstState::Playing.into() {
+                        self.controls.pause().await;
+                        std::thread::sleep(Duration::from_millis(500));
                     }
                     self.controls.stop().await;
                     std::thread::sleep(Duration::from_millis(500));

--- a/hifirs/src/ui/mod.rs
+++ b/hifirs/src/ui/mod.rs
@@ -6,55 +6,53 @@ pub mod search;
 use crate::{
     player::Controls,
     qobuz::SearchResults,
-    sql::db::Database,
     state::{
-        app::{AppKey, StateKey},
+        app::{PlayerState, SafePlayerState},
         ActiveScreen,
     },
     switch_screen,
     ui::{nowplaying::NowPlayingScreen, playlists::MyPlaylistsScreen, search::SearchScreen},
     REFRESH_RESOLUTION,
 };
+use async_trait::async_trait;
 use flume::{Receiver, Sender};
 use gstreamer::State as GstState;
 use qobuz_client::client::api::Client;
 use snafu::prelude::*;
-use std::{cell::RefCell, collections::HashMap, io::Stdout, rc::Rc, thread, time::Duration};
+use std::{collections::HashMap, io::Stdout, sync::Arc, thread, time::Duration};
 use termion::{
     event::{Event as TermEvent, Key, MouseEvent},
     input::{MouseTerminal, TermRead},
     raw::{IntoRawMode, RawTerminal},
     screen::AlternateScreen,
 };
-use tokio::select;
+use tokio::{select, sync::Mutex};
 use tokio_stream::StreamExt;
 use tui::{backend::TermionBackend, Terminal};
 
 #[macro_export]
 macro_rules! switch_screen {
-    ($db:expr, $screen:path) => {
-        use $crate::state::app::AppKey;
-        use $crate::state::app::StateKey;
+    ($state:expr, $screen:path) => {
         use $crate::state::ActiveScreen;
 
-        $db.insert::<String, ActiveScreen>(StateKey::App(AppKey::ActiveScreen), $screen)
-            .await;
+        $state.set_active_screen($screen);
     };
 }
 
+#[async_trait]
 pub trait Screen {
-    fn render(&mut self, terminal: &mut Console);
-    fn key_events(&mut self, key: Key) -> Option<()>;
+    fn render(&mut self, state: PlayerState, terminal: &mut Console);
+    async fn key_events(&mut self, key: Key) -> Option<()>;
 }
 
 #[allow(unused)]
 pub struct Tui {
     rx: Receiver<Event>,
     tx: Sender<Event>,
-    db: Database,
     controls: Controls,
     terminal: Console,
-    screens: HashMap<ActiveScreen, Rc<RefCell<dyn Screen>>>,
+    screens: HashMap<ActiveScreen, Arc<Mutex<dyn Screen>>>,
+    state: SafePlayerState,
 }
 
 type Console = Terminal<TermionBackend<AlternateScreen<MouseTerminal<RawTerminal<Stdout>>>>>;
@@ -97,7 +95,7 @@ impl From<std::io::Error> for Error {
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 pub async fn new(
-    db: Database,
+    state: SafePlayerState,
     controls: Controls,
     client: Client,
     search_results: Option<SearchResults>,
@@ -112,54 +110,52 @@ pub async fn new(
 
     let (tx, rx) = flume::unbounded();
 
-    if let Some(search_results) = &search_results {
-        match search_results {
-            SearchResults::UserPlaylists(_) => {
-                switch_screen!(db, ActiveScreen::Playlists);
-            }
-            _ => {
-                switch_screen!(db, ActiveScreen::Search);
-            }
-        }
-    }
-
     let mut screens = HashMap::new();
     screens.insert(
         ActiveScreen::Search,
-        Rc::new(RefCell::new(SearchScreen::new(
-            db.clone(),
+        Arc::new(Mutex::new(SearchScreen::new(
             controls.clone(),
             client.clone(),
-            search_results,
+            search_results.clone(),
             query,
             terminal.size().unwrap().width,
-        ))) as Rc<RefCell<dyn Screen>>,
+        ))) as Arc<Mutex<dyn Screen>>,
     );
     screens.insert(
         ActiveScreen::NowPlaying,
-        Rc::new(RefCell::new(NowPlayingScreen::new(
-            db.clone(),
-            controls.clone(),
-        ))) as Rc<RefCell<dyn Screen>>,
+        Arc::new(Mutex::new(NowPlayingScreen::new(controls.clone()))) as Arc<Mutex<dyn Screen>>,
     );
 
     screens.insert(
         ActiveScreen::Playlists,
-        Rc::new(RefCell::new(MyPlaylistsScreen::new(
-            db.clone(),
-            client,
-            controls.clone(),
-        ))) as Rc<RefCell<dyn Screen>>,
+        Arc::new(Mutex::new(
+            MyPlaylistsScreen::new(client, controls.clone()).await,
+        )) as Arc<Mutex<dyn Screen>>,
     );
 
-    Ok(Tui {
-        db,
+    let tui = Tui {
         controls,
+        state: state.clone(),
         rx,
         terminal,
         tx,
         screens,
-    })
+    };
+
+    if let Some(results) = search_results {
+        let mut state = state.write().await;
+
+        match results {
+            SearchResults::UserPlaylists(_) => {
+                switch_screen!(state, ActiveScreen::Playlists);
+            }
+            _ => {
+                switch_screen!(state, ActiveScreen::Search);
+            }
+        }
+    }
+
+    Ok(tui)
 }
 
 impl Tui {
@@ -169,25 +165,18 @@ impl Tui {
         }
     }
     async fn render(&mut self) {
-        let screen = if let Some(saved_screen) = self
-            .db
-            .get::<String, ActiveScreen>(StateKey::App(AppKey::ActiveScreen))
-            .await
-        {
-            saved_screen
-        } else {
-            ActiveScreen::NowPlaying
-        };
+        let state = self.state.read().await.clone();
+        let screen = state.active_screen();
 
         if let Some(screen) = self.screens.get(&screen) {
-            screen.borrow_mut().render(&mut self.terminal);
+            screen.lock().await.render(state, &mut self.terminal);
         }
     }
     pub async fn event_loop<'c>(&mut self) -> Result<()> {
         // Watches stdin for input events and sends them to the
         // router for handling.
         let event_sender = self.tx.clone();
-        let mut q = self.db.quitter();
+        let mut q = self.state.read().await.quitter();
         thread::spawn(move || {
             let stdin = std::io::stdin();
             for event in stdin.events().flatten() {
@@ -206,7 +195,7 @@ impl Tui {
         // Sends a tick whose interval is defined by
         // REFRESH_RESOLUTION
         let event_sender = self.tx.clone();
-        let mut q = self.db.quitter();
+        let mut q = self.state.read().await.quitter();
         thread::spawn(move || loop {
             if let Ok(quit) = q.try_recv() {
                 if quit {
@@ -218,13 +207,14 @@ impl Tui {
                     "error sending tick, app is probably just closing. err: {}",
                     err.to_string()
                 );
+                return;
             }
             std::thread::sleep(Duration::from_millis(REFRESH_RESOLUTION));
         });
 
         let event_receiver = self.rx.clone();
         let mut event_stream = event_receiver.stream();
-        let mut quitter = self.db.quitter();
+        let mut quitter = self.state.read().await.quitter();
 
         loop {
             select! {
@@ -248,24 +238,21 @@ impl Tui {
             }
             Event::Key(key) => match key {
                 Key::Char('\t') => {
-                    if let Some(active_screen) = self
-                        .db
-                        .get::<String, ActiveScreen>(StateKey::App(AppKey::ActiveScreen))
-                        .await
-                    {
-                        match active_screen {
-                            ActiveScreen::NowPlaying => {
-                                switch_screen!(self.db, ActiveScreen::Search);
-                                self.tick().await;
-                            }
-                            ActiveScreen::Search => {
-                                switch_screen!(self.db, ActiveScreen::Playlists);
-                                self.tick().await;
-                            }
-                            ActiveScreen::Playlists => {
-                                switch_screen!(self.db, ActiveScreen::NowPlaying);
-                                self.tick().await;
-                            }
+                    let mut state = self.state.write().await;
+                    let active_screen = state.active_screen();
+
+                    match active_screen {
+                        ActiveScreen::NowPlaying => {
+                            switch_screen!(state, ActiveScreen::Search);
+                            self.tick().await;
+                        }
+                        ActiveScreen::Search => {
+                            switch_screen!(state, ActiveScreen::Playlists);
+                            self.tick().await;
+                        }
+                        ActiveScreen::Playlists => {
+                            switch_screen!(state, ActiveScreen::NowPlaying);
+                            self.tick().await;
                         }
                     }
                 }
@@ -278,18 +265,13 @@ impl Tui {
                     }
                     self.controls.stop().await;
                     std::thread::sleep(Duration::from_millis(500));
-                    self.db.quit();
+                    self.state.read().await.quit();
                 }
                 _ => {
-                    if let Some(active_screen) = self
-                        .db
-                        .get::<String, ActiveScreen>(StateKey::App(AppKey::ActiveScreen))
-                        .await
+                    if let Some(screen) = self.screens.get(&self.state.read().await.active_screen())
                     {
-                        if let Some(screen) = self.screens.get(&active_screen) {
-                            if screen.borrow_mut().key_events(key).is_some() {
-                                self.tick().await;
-                            }
+                        if screen.lock().await.key_events(key).await.is_some() {
+                            self.tick().await;
                         }
                     };
                 }

--- a/hifirs/src/ui/nowplaying.rs
+++ b/hifirs/src/ui/nowplaying.rs
@@ -15,6 +15,7 @@ pub struct NowPlayingScreen {
     track_list: Table,
     controls: Controls,
     list_height: usize,
+    current_track_index: usize,
 }
 
 impl NowPlayingScreen {
@@ -25,6 +26,7 @@ impl NowPlayingScreen {
             track_list,
             controls,
             list_height: 0,
+            current_track_index: 0,
         }
     }
 }
@@ -32,6 +34,10 @@ impl NowPlayingScreen {
 #[async_trait]
 impl Screen for NowPlayingScreen {
     fn render(&mut self, state: PlayerState, terminal: &mut Console) {
+        if let Some(current_track_index) = state.current_track_index() {
+            self.current_track_index = current_track_index;
+        }
+
         terminal
             .draw(|f| {
                 let layout = Layout::default()
@@ -147,8 +153,12 @@ impl Screen for NowPlayingScreen {
                 }
                 '\n' => {
                     if let Some(selection) = self.track_list.selected() {
-                        debug!("playing selected track {}", selection);
-                        self.controls.skip_to(selection).await;
+                        debug!("****************** CURRENT {:?}", self.current_track_index);
+                        debug!(
+                            "playing selected track {}",
+                            selection + self.current_track_index + 1
+                        );
+                        // self.controls.skip_to(selection).await;
                     }
 
                     Some(())

--- a/hifirs/src/ui/nowplaying.rs
+++ b/hifirs/src/ui/nowplaying.rs
@@ -158,7 +158,7 @@ impl Screen for NowPlayingScreen {
                             "playing selected track {}",
                             selection + self.current_track_index + 1
                         );
-                        // self.controls.skip_to(selection).await;
+                        self.controls.skip_to(selection).await;
                     }
 
                     Some(())

--- a/hifirs/src/ui/nowplaying.rs
+++ b/hifirs/src/ui/nowplaying.rs
@@ -1,39 +1,37 @@
 use crate::{
     player::Controls,
-    sql::db::Database,
-    state::{app::PlayerKey, TrackListValue},
+    state::app::PlayerState,
     ui::{
-        components::{self, Row, Table, TableHeaders, TableRows, TableWidths},
-        Console, Screen, StateKey,
+        components::{self, Table, TableHeaders, TableWidths},
+        Console, Screen,
     },
 };
-use futures::executor;
+use async_trait::async_trait;
 use qobuz_client::client::track::Track;
 use termion::event::Key;
 use tui::layout::{Constraint, Direction, Layout};
 
 pub struct NowPlayingScreen {
     track_list: Table,
-    db: Database,
     controls: Controls,
     list_height: usize,
 }
 
 impl NowPlayingScreen {
-    pub fn new(db: Database, controls: Controls) -> NowPlayingScreen {
+    pub fn new(controls: Controls) -> NowPlayingScreen {
         let track_list = Table::new(None, None, None);
 
         NowPlayingScreen {
             track_list,
-            db,
             controls,
             list_height: 0,
         }
     }
 }
 
+#[async_trait]
 impl Screen for NowPlayingScreen {
-    fn render(&mut self, terminal: &mut Console) {
+    fn render(&mut self, state: PlayerState, terminal: &mut Console) {
         terminal
             .draw(|f| {
                 let layout = Layout::default()
@@ -49,45 +47,23 @@ impl Screen for NowPlayingScreen {
 
                 self.list_height = (split_layout[1].height - split_layout[1].y) as usize;
 
-                components::player(f, split_layout[0], self.db.clone());
+                components::player(f, split_layout[0], state.clone());
 
-                let mut title = "Now Playing".to_string();
+                let rows = state.rows();
 
-                if let Some(tracklist) = executor::block_on(
-                    self.db
-                        .get::<String, TrackListValue>(StateKey::Player(PlayerKey::Playlist)),
-                ) {
-                    let mut rows = tracklist.rows();
-
-                    if let Some(prev_playlist) =
-                        executor::block_on(self.db.get::<String, TrackListValue>(StateKey::Player(
-                            PlayerKey::PreviousPlaylist,
-                        )))
-                    {
-                        let prev_rows = prev_playlist.rows();
-                        rows.append(
-                            &mut prev_rows
-                                .into_iter()
-                                .map(|mut r| {
-                                    r.set_dim(true);
-                                    r
-                                })
-                                .collect::<Vec<Row>>(),
-                        )
-                    }
-
+                if !self.track_list.compare_rows(&rows) {
                     self.track_list.set_rows(rows);
                     self.track_list.set_header(Track::headers());
                     self.track_list.set_widths(Track::widths());
-
-                    title = if let Some(album) = tracklist.get_album() {
-                        format!("Album: {}", album.title)
-                    } else if let Some(playlist) = tracklist.get_playlist() {
-                        format!("Playlist: {}", playlist.name)
-                    } else {
-                        "Now Playing".to_string()
-                    };
                 }
+
+                let title = if let Some(album) = state.album() {
+                    format!("Album: {}", album.title)
+                } else if let Some(playlist) = state.playlist() {
+                    format!("Playlist: {}", playlist.name)
+                } else {
+                    "Now Playing".to_string()
+                };
 
                 components::table(f, &mut self.track_list, title.as_str(), split_layout[1]);
                 components::tabs(0, f, split_layout[2]);
@@ -95,7 +71,7 @@ impl Screen for NowPlayingScreen {
             .expect("failed to draw screen");
     }
 
-    fn key_events(&mut self, key: Key) -> Option<()> {
+    async fn key_events(&mut self, key: Key) -> Option<()> {
         match key {
             Key::Down | Key::Char('j') => {
                 self.track_list.next();
@@ -105,12 +81,12 @@ impl Screen for NowPlayingScreen {
                 self.track_list.previous();
                 Some(())
             }
-            Key::Right | Key::Char('h') => {
-                executor::block_on(self.controls.jump_forward());
+            Key::Right | Key::Char('l') => {
+                self.controls.jump_forward().await;
                 Some(())
             }
-            Key::Left | Key::Char('l') => {
-                executor::block_on(self.controls.jump_backward());
+            Key::Left | Key::Char('h') => {
+                self.controls.jump_backward().await;
                 Some(())
             }
             Key::Home => {
@@ -122,7 +98,7 @@ impl Screen for NowPlayingScreen {
                 Some(())
             }
             Key::PageDown => {
-                let page_height = (self.list_height / 2) as usize;
+                let page_height = self.list_height / 2;
 
                 if let Some(selected) = self.track_list.selected() {
                     if selected == 0 {
@@ -141,7 +117,7 @@ impl Screen for NowPlayingScreen {
                 }
             }
             Key::PageUp => {
-                let page_height = (self.list_height / 2) as usize;
+                let page_height = self.list_height / 2;
 
                 if let Some(selected) = self.track_list.selected() {
                     if selected < page_height {
@@ -158,21 +134,21 @@ impl Screen for NowPlayingScreen {
             }
             Key::Char(c) => match c {
                 ' ' => {
-                    executor::block_on(self.controls.play_pause());
+                    self.controls.play_pause().await;
                     Some(())
                 }
                 'N' => {
-                    executor::block_on(self.controls.next());
+                    self.controls.next().await;
                     Some(())
                 }
                 'P' => {
-                    executor::block_on(self.controls.previous());
+                    self.controls.previous().await;
                     Some(())
                 }
                 '\n' => {
                     if let Some(selection) = self.track_list.selected() {
                         debug!("playing selected track {}", selection);
-                        executor::block_on(self.controls.skip_to(selection));
+                        self.controls.skip_to(selection).await;
                     }
 
                     Some(())
@@ -181,8 +157,6 @@ impl Screen for NowPlayingScreen {
             },
 
             _ => None,
-        };
-
-        None
+        }
     }
 }

--- a/hifirs/src/ui/playlists.rs
+++ b/hifirs/src/ui/playlists.rs
@@ -215,11 +215,6 @@ impl<'m> Screen for MyPlaylistsScreen<'m> {
                                         self.controls.play_track(track.id).await;
                                         self.show_album_or_track_popup = false;
 
-                                        // executor::block_on(self.db.insert::<String, ActiveScreen>(
-                                        //     StateKey::App(AppKey::ActiveScreen),
-                                        //     ActiveScreen::NowPlaying,
-                                        // ));
-
                                         return Some(());
                                     } else {
                                         return None;

--- a/hifirs/src/ui/playlists.rs
+++ b/hifirs/src/ui/playlists.rs
@@ -212,7 +212,7 @@ impl<'m> Screen for MyPlaylistsScreen<'m> {
                                             return None;
                                         }
                                     } else if self.show_album_or_track_selection == 1 {
-                                        self.controls.play_track(track.clone()).await;
+                                        self.controls.play_track(track.id).await;
                                         self.show_album_or_track_popup = false;
 
                                         // executor::block_on(self.db.insert::<String, ActiveScreen>(
@@ -242,7 +242,7 @@ impl<'m> Screen for MyPlaylistsScreen<'m> {
                                     );
                                     debug!("fetching tracks for selected playlist");
                                     if let Ok(mut playlist_info) =
-                                        self.client.playlist(list.id.to_string()).await
+                                        self.client.playlist(list.id).await
                                     {
                                         debug!("received playlist, adding to table");
                                         playlist_info.reverse();
@@ -269,9 +269,9 @@ impl<'m> Screen for MyPlaylistsScreen<'m> {
                             {
                                 if let Some(playlist) = results.playlists.items.get(selected) {
                                     if let Ok(full_playlist) =
-                                        self.client.playlist(playlist.id.to_string()).await
+                                        self.client.playlist(playlist.id).await
                                     {
-                                        self.controls.play_playlist(full_playlist).await;
+                                        self.controls.play_playlist(full_playlist.id).await;
                                         self.show_play_or_open_popup = false;
 
                                         return Some(());

--- a/hifirs/src/ui/playlists.rs
+++ b/hifirs/src/ui/playlists.rs
@@ -1,12 +1,15 @@
 use crate::{
-    sql::db::Database,
-    state::{
-        app::{AppKey, StateKey},
-        ActiveScreen,
+    player::Controls,
+    ui::{
+        components::{self, Item, List},
+        Console, Screen,
     },
+};
+use crate::{
+    state::app::PlayerState,
     ui::components::{Table, TableHeaders, TableRows, TableWidths},
 };
-use futures::executor;
+use async_trait::async_trait;
 use qobuz_client::client::{
     api::Client,
     playlist::{Playlist, UserPlaylistsResult},
@@ -20,17 +23,8 @@ use tui::{
     widgets::{Block, BorderType, Borders, ListItem, Tabs},
 };
 
-use crate::{
-    player::Controls,
-    ui::{
-        components::{self, Item, List},
-        Console, Screen,
-    },
-};
-
 pub struct MyPlaylistsScreen<'m> {
     controls: Controls,
-    db: Database,
     client: Client,
     mylist_results: Option<UserPlaylistsResult>,
     mylists: List<'m>,
@@ -46,7 +40,7 @@ pub struct MyPlaylistsScreen<'m> {
 }
 
 impl<'m> MyPlaylistsScreen<'m> {
-    pub fn new(db: Database, client: Client, controls: Controls) -> Self {
+    pub async fn new(client: Client, controls: Controls) -> MyPlaylistsScreen<'m> {
         let mylists = List::new(None);
         let selected_playlist = Table::new(None, None, None);
 
@@ -55,7 +49,6 @@ impl<'m> MyPlaylistsScreen<'m> {
             show_album_or_track_selection: 0,
             screen_height: 0,
             screen_width: 0,
-            db,
             client,
             mylist_results: None,
             mylists,
@@ -66,13 +59,13 @@ impl<'m> MyPlaylistsScreen<'m> {
             show_play_or_open_popup_selection: 0,
             show_selected_playlist: false,
         };
-        screen.refresh_lists();
+        screen.refresh_lists().await;
 
         screen
     }
 
-    fn refresh_lists(&mut self) {
-        if let Ok(my_lists) = executor::block_on(self.client.user_playlists()) {
+    async fn refresh_lists(&mut self) {
+        if let Ok(my_lists) = self.client.user_playlists().await {
             let list: Vec<String> = my_lists.clone().into();
             let items = list
                 .into_iter()
@@ -85,8 +78,9 @@ impl<'m> MyPlaylistsScreen<'m> {
     }
 }
 
+#[async_trait]
 impl<'m> Screen for MyPlaylistsScreen<'m> {
-    fn render(&mut self, terminal: &mut Console) {
+    fn render(&mut self, state: PlayerState, terminal: &mut Console) {
         terminal
             .draw(|f| {
                 self.screen_height = f.size().height as usize;
@@ -102,7 +96,7 @@ impl<'m> Screen for MyPlaylistsScreen<'m> {
                     .margin(0)
                     .split(f.size());
 
-                components::player(f, layout[0], self.db.clone());
+                components::player(f, layout[0], state);
 
                 if self.show_selected_playlist {
                     components::table(
@@ -168,29 +162,29 @@ impl<'m> Screen for MyPlaylistsScreen<'m> {
             .expect("failed to draw screen");
     }
 
-    fn key_events(&mut self, key: Key) -> Option<()> {
+    async fn key_events(&mut self, key: Key) -> Option<()> {
         if self.show_album_or_track_popup || self.show_play_or_open_popup {
             match key {
                 Key::Right | Key::Left | Key::Char('h') | Key::Char('l') => {
                     if self.show_album_or_track_popup {
                         if self.show_album_or_track_selection == 0 {
                             self.show_album_or_track_selection = 1;
+                            return Some(());
                         } else if self.show_album_or_track_selection == 1 {
                             self.show_album_or_track_selection = 0;
+                            return Some(());
                         }
+                    }
 
-                        Some(())
-                    } else if self.show_play_or_open_popup {
+                    if self.show_play_or_open_popup {
                         if self.show_play_or_open_popup_selection == 0 {
                             self.show_play_or_open_popup_selection = 1;
+                            return Some(());
                         } else if self.show_play_or_open_popup_selection == 1 {
                             self.show_play_or_open_popup_selection = 0;
+                            return Some(());
                         }
-
-                        Some(())
-                    } else {
-                        None
-                    };
+                    }
                 }
                 Key::Esc => {
                     if self.show_play_or_open_popup {
@@ -210,37 +204,25 @@ impl<'m> Screen for MyPlaylistsScreen<'m> {
                                 if let Some(track) = tracks.items.get(selected) {
                                     if self.show_album_or_track_selection == 0 {
                                         if let Some(album) = &track.album {
-                                            if let Ok(album) = executor::block_on(
-                                                self.client.album(album.id.clone()),
-                                            ) {
-                                                executor::block_on(self.controls.play_album(album));
-                                                self.show_album_or_track_popup = false;
+                                            self.controls.play_album(album.id.clone()).await;
+                                            self.show_album_or_track_popup = false;
 
-                                                executor::block_on(
-                                                    self.db.insert::<String, ActiveScreen>(
-                                                        StateKey::App(AppKey::ActiveScreen),
-                                                        ActiveScreen::NowPlaying,
-                                                    ),
-                                                );
-                                                Some(())
-                                            } else {
-                                                None
-                                            }
+                                            return Some(());
                                         } else {
-                                            None
+                                            return None;
                                         }
                                     } else if self.show_album_or_track_selection == 1 {
-                                        executor::block_on(self.controls.play_track(track.clone()));
+                                        self.controls.play_track(track.clone()).await;
                                         self.show_album_or_track_popup = false;
 
-                                        executor::block_on(self.db.insert::<String, ActiveScreen>(
-                                            StateKey::App(AppKey::ActiveScreen),
-                                            ActiveScreen::NowPlaying,
-                                        ));
+                                        // executor::block_on(self.db.insert::<String, ActiveScreen>(
+                                        //     StateKey::App(AppKey::ActiveScreen),
+                                        //     ActiveScreen::NowPlaying,
+                                        // ));
 
-                                        Some(())
+                                        return Some(());
                                     } else {
-                                        None
+                                        return None;
                                     };
                                 }
                             }
@@ -259,9 +241,9 @@ impl<'m> Screen for MyPlaylistsScreen<'m> {
                                         list.name, list.id
                                     );
                                     debug!("fetching tracks for selected playlist");
-                                    if let Ok(mut playlist_info) = executor::block_on(
-                                        self.client.playlist(list.id.to_string()),
-                                    ) {
+                                    if let Ok(mut playlist_info) =
+                                        self.client.playlist(list.id.to_string()).await
+                                    {
                                         debug!("received playlist, adding to table");
                                         playlist_info.reverse();
 
@@ -275,9 +257,9 @@ impl<'m> Screen for MyPlaylistsScreen<'m> {
                                         self.show_selected_playlist = true;
                                         self.show_play_or_open_popup = false;
 
-                                        Some(())
+                                        return Some(());
                                     } else {
-                                        None
+                                        return None;
                                     };
                                 }
                             }
@@ -286,23 +268,15 @@ impl<'m> Screen for MyPlaylistsScreen<'m> {
                                 (&self.mylist_results, self.mylists.selected())
                             {
                                 if let Some(playlist) = results.playlists.items.get(selected) {
-                                    if let Ok(full_playlist) = executor::block_on(
-                                        self.client.playlist(playlist.id.to_string()),
-                                    ) {
-                                        executor::block_on(
-                                            self.controls.play_playlist(full_playlist),
-                                        );
-
+                                    if let Ok(full_playlist) =
+                                        self.client.playlist(playlist.id.to_string()).await
+                                    {
+                                        self.controls.play_playlist(full_playlist).await;
                                         self.show_play_or_open_popup = false;
 
-                                        executor::block_on(self.db.insert::<String, ActiveScreen>(
-                                            StateKey::App(AppKey::ActiveScreen),
-                                            ActiveScreen::NowPlaying,
-                                        ));
-
-                                        Some(())
+                                        return Some(());
                                     } else {
-                                        None
+                                        return None;
                                     };
                                 }
                             }
@@ -317,65 +291,65 @@ impl<'m> Screen for MyPlaylistsScreen<'m> {
             match key {
                 Key::Down | Key::Char('j') => {
                     self.selected_playlist_table.next();
-                    Some(())
+                    return Some(());
                 }
                 Key::Up | Key::Char('k') => {
                     self.selected_playlist_table.previous();
-                    Some(())
+                    return Some(());
                 }
                 Key::Esc => {
                     self.show_selected_playlist = false;
-                    Some(())
+                    return Some(());
                 }
                 Key::Home => {
                     self.selected_playlist_table.home();
-                    Some(())
+                    return Some(());
                 }
                 Key::End => {
                     self.selected_playlist_table.end();
-                    Some(())
+                    return Some(());
                 }
                 Key::PageDown => {
-                    let page_height = (self.screen_height / 2) as usize;
+                    let page_height = self.screen_height / 2;
 
                     if let Some(selected) = self.selected_playlist_table.selected() {
                         if selected == 0 {
                             self.selected_playlist_table.select(page_height * 2);
-                            Some(())
+                            return Some(());
                         } else if selected + page_height > self.selected_playlist_table.len() - 1 {
                             self.selected_playlist_table
                                 .select(self.selected_playlist_table.len() - 1);
-                            Some(())
+                            return Some(());
                         } else {
                             self.selected_playlist_table.select(selected + page_height);
-                            Some(())
+                            return Some(());
                         }
                     } else {
                         self.selected_playlist_table.select(page_height);
-                        Some(())
+                        return Some(());
                     }
                 }
                 Key::PageUp => {
-                    let page_height = (self.screen_height / 2) as usize;
+                    let page_height = self.screen_height / 2;
 
                     if let Some(selected) = self.selected_playlist_table.selected() {
                         if selected < page_height {
                             self.selected_playlist_table.select(0);
-                            Some(())
+                            return Some(());
                         } else {
                             self.selected_playlist_table.select(selected - page_height);
-                            Some(())
+                            return Some(());
                         }
                     } else {
                         self.selected_playlist_table.select(page_height);
-                        Some(())
+                        return Some(());
                     }
                 }
                 Key::Char('\n') => {
                     self.show_album_or_track_popup = true;
-                    Some(())
+                    return Some(());
                 }
-                _ => None,
+                _ => return None,
             };
         }
 
@@ -398,7 +372,7 @@ impl<'m> Screen for MyPlaylistsScreen<'m> {
             }
             Key::Char(char) => match char {
                 'r' => {
-                    self.refresh_lists();
+                    self.refresh_lists().await;
                     Some(())
                 }
                 '\n' => {

--- a/hifirs/src/ui/search.rs
+++ b/hifirs/src/ui/search.rs
@@ -124,7 +124,11 @@ impl Screen for SearchScreen {
                     .margin(0)
                     .split(f.size());
 
-                self.results_height = (layout[2].height - layout[2].y) as usize;
+                self.results_height = if layout[2].height > layout[2].y {
+                    (layout[2].height - layout[2].y) as usize
+                } else {
+                    1
+                };
 
                 components::player(f, layout[0], state);
 

--- a/hifirs/src/ui/search.rs
+++ b/hifirs/src/ui/search.rs
@@ -160,42 +160,44 @@ impl Screen for SearchScreen {
             Key::Up | Key::Char('k') => {
                 if self.enter_search {
                     self.search_query.push('k');
+                    return Some(());
                 } else {
                     self.results_table.previous();
+                    return Some(());
                 }
-                Some(())
             }
             Key::Down | Key::Char('j') => {
                 if self.enter_search {
                     self.search_query.push('j');
+                    return Some(());
                 } else {
                     self.results_table.next();
+                    return Some(());
                 }
-                Some(())
             }
             Key::Backspace => {
                 if self.enter_search {
                     self.search_query.pop();
-                    Some(())
+                    return Some(());
                 } else {
-                    None
+                    return None;
                 }
             }
             Key::Esc => {
                 if self.enter_search {
                     self.enter_search = false;
-                    Some(())
+                    return Some(());
                 } else {
-                    None
+                    return None;
                 }
             }
             Key::Home => {
                 self.results_table.home();
-                Some(())
+                return Some(());
             }
             Key::End => {
                 self.results_table.end();
-                Some(())
+                return Some(());
             }
             Key::PageDown => {
                 let page_height = self.results_height / 2;
@@ -255,14 +257,14 @@ impl Screen for SearchScreen {
                         }
                     }
 
-                    None
+                    return None;
                 }
                 '/' => {
                     if !self.enter_search {
                         self.enter_search = true;
                         return Some(());
                     } else {
-                        None
+                        return None;
                     }
                 }
                 char => {
@@ -276,7 +278,5 @@ impl Screen for SearchScreen {
             },
             _ => return None,
         };
-
-        None
     }
 }

--- a/playlist-sync/src/cli.rs
+++ b/playlist-sync/src/cli.rs
@@ -4,17 +4,17 @@ use console::Term;
 use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
 use rspotify::model::PlaylistId;
 use snafu::Snafu;
-use std::{str::FromStr, time::Duration};
+use std::time::Duration;
 
 const TITLE: &str = r#"
-╔═╗ ┌─┐┌┐ ┬ ┬┌─┐      
-║═╬╗│ │├┴┐│ │┌─┘      
-╚═╝╚└─┘└─┘└─┘└─┘      
+╔═╗ ┌─┐┌┐ ┬ ┬┌─┐
+║═╬╗│ │├┴┐│ │┌─┘
+╚═╝╚└─┘└─┘└─┘└─┘
 ╔═╗┬  ┌─┐┬ ┬┬  ┬┌─┐┌┬┐
-╠═╝│  ├─┤└┬┘│  │└─┐ │ 
-╩  ┴─┘┴ ┴ ┴ ┴─┘┴└─┘ ┴ 
-╔═╗┬ ┬┌┐┌┌─┐          
-╚═╗└┬┘││││            
+╠═╝│  ├─┤└┬┘│  │└─┐ │
+╩  ┴─┘┴ ┴ ┴ ┴─┘┴└─┘ ┴
+╔═╗┬ ┬┌┐┌┌─┐
+╚═╗└┬┘││││
 ╚═╝ ┴ ┘└┘└─┘
 "#;
 
@@ -89,7 +89,7 @@ pub async fn run() -> Result<(), Error> {
 
     let spotify_playlist = spotify
         .playlist(
-            PlaylistId::from_str(cli.spotify_playlist_id.as_str())
+            PlaylistId::from_id(cli.spotify_playlist_id.as_str())
                 .expect("invalid spotify playlist id"),
         )
         .await?;

--- a/playlist-sync/src/cli.rs
+++ b/playlist-sync/src/cli.rs
@@ -26,7 +26,7 @@ struct Cli {
     pub spotify_playlist_id: String,
     /// Qobuz client to sync to
     #[clap(short = 'q', long = "qobuz")]
-    pub qobuz_playlist_id: String,
+    pub qobuz_playlist_id: i64,
 }
 
 #[derive(Debug, Snafu)]

--- a/playlist-sync/src/qobuz.rs
+++ b/playlist-sync/src/qobuz.rs
@@ -57,7 +57,7 @@ impl<'q> Qobuz<'q> {
         self.progress.set_message("signed into Qobuz");
     }
 
-    pub async fn playlist(&self, playlist_id: String) -> Result<QobuzPlaylist> {
+    pub async fn playlist(&self, playlist_id: i64) -> Result<QobuzPlaylist> {
         self.progress
             .set_message(format!("fetching playlist: {playlist_id}"));
 

--- a/playlist-sync/src/qobuz.rs
+++ b/playlist-sync/src/qobuz.rs
@@ -50,6 +50,10 @@ impl<'q> Qobuz<'q> {
             .await
             .expect("failed to refresh config");
         self.client.login().await.expect("failed to login");
+        // self.client
+        //     .test_secrets()
+        //     .await
+        //     .expect("failed to test secrets");
         self.progress.set_message("signed into Qobuz");
     }
 
@@ -136,7 +140,7 @@ impl QobuzPlaylist {
 
     pub fn track_count(&self) -> usize {
         if let Some(tracks) = &self.0.tracks {
-            tracks.items.len() as usize
+            tracks.items.len()
         } else {
             0
         }

--- a/playlist-sync/src/qobuz.rs
+++ b/playlist-sync/src/qobuz.rs
@@ -59,7 +59,7 @@ impl<'q> Qobuz<'q> {
 
     pub async fn playlist(&self, playlist_id: String) -> Result<QobuzPlaylist> {
         self.progress
-            .set_message(format!("fetching playlist: {}", playlist_id));
+            .set_message(format!("fetching playlist: {playlist_id}"));
 
         let playlist = self.client.playlist(playlist_id).await?;
 

--- a/playlist-sync/src/spotify.rs
+++ b/playlist-sync/src/spotify.rs
@@ -81,7 +81,7 @@ impl<'s> Spotify<'s> {
                         if webbrowser::open(&url).is_ok() {
                             self.wait_for_auth().await;
                         } else {
-                            println!("There was a problem opening the browser, please open this url manually:\n{}", url);
+                            println!("There was a problem opening the browser, please open this url manually:\n{url}");
                             self.wait_for_auth().await;
                         }
                     }
@@ -95,8 +95,7 @@ impl<'s> Spotify<'s> {
                 self.wait_for_auth().await;
             } else {
                 println!(
-                    "There was a problem opening the browser, please open this url manually:\n{}",
-                    url
+                    "There was a problem opening the browser, please open this url manually:\n{url}",
                 );
                 self.wait_for_auth().await;
             }

--- a/playlist-sync/src/spotify.rs
+++ b/playlist-sync/src/spotify.rs
@@ -75,20 +75,29 @@ impl<'s> Spotify<'s> {
                         *self.client.get_token().lock().await.unwrap() = Some(refreshed_token);
                     }
                     None => {
-                        debug!("no cached token, authorizing client");
+                        debug!("no cached token, getting auth url");
                         let url = self.client.get_authorize_url(true).unwrap();
 
                         if webbrowser::open(&url).is_ok() {
+                            self.wait_for_auth().await;
+                        } else {
+                            println!("There was a problem opening the browser, please open this url manually:\n{}", url);
                             self.wait_for_auth().await;
                         }
                     }
                 }
             }
         } else {
-            debug!("no cached token, authorizing client");
+            debug!("no cached token, getting auth url");
             let url = self.client.get_authorize_url(true).unwrap();
 
             if webbrowser::open(&url).is_ok() {
+                self.wait_for_auth().await;
+            } else {
+                println!(
+                    "There was a problem opening the browser, please open this url manually:\n{}",
+                    url
+                );
                 self.wait_for_auth().await;
             }
         }
@@ -141,15 +150,18 @@ impl<'s> Spotify<'s> {
         all_playlists
     }
 
-    pub async fn playlist(&self, playlist_id: PlaylistId) -> Result<SpotifyFullPlaylist> {
+    pub async fn playlist(&self, playlist_id: PlaylistId<'_>) -> Result<SpotifyFullPlaylist> {
         self.progress
             .set_message(format!("fetching playlist: {playlist_id}"));
         debug!("fetching playlist {}", playlist_id.to_string());
 
-        let spotify_playlist = self.client.playlist(&playlist_id, None, None).await?;
+        let spotify_playlist = self
+            .client
+            .playlist(playlist_id.clone(), None, None)
+            .await?;
 
         debug!("fetching all spotify playlist items");
-        let items = self.client.playlist_items(&playlist_id, None, None);
+        let items = self.client.playlist_items(playlist_id, None, None);
 
         match items.try_collect::<Vec<PlaylistItem>>().await {
             Ok(full_list) => {
@@ -224,7 +236,7 @@ impl SpotifyFullPlaylist {
     }
 
     pub fn track_count(&self) -> usize {
-        self.all_tracks.len() as usize
+        self.all_tracks.len()
     }
 }
 

--- a/qobuz-client/Cargo.toml
+++ b/qobuz-client/Cargo.toml
@@ -6,12 +6,8 @@ edition = "2021"
 [dependencies]
 base64 = "0.13"
 bincode = "1.3"
-byteorder = "1.4"
 chrono = "0.4"
 clap = { version = "4", features = ["derive"] }
-enum-as-inner = "0.5"
-flume = "0.10"
-futures = "0.3"
 gstreamer = { version = "0.18", features = ["ser_de"] }
 log = "0.4"
 md5 = "0.7.0"
@@ -22,12 +18,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 snafu = "0.7"
 tokio = { version = "1.0", features = ["full"]}
-tokio-test = "0.4"
 url = "2.2"
 util = { path = "../util" }
-zerocopy = "0.6"
 
 [dev-dependencies]
 tokio-test = "0.4"
-nanoid = "0.4.0"
 insta = { version = "1.21", features = [ "yaml", "redactions" ] }

--- a/qobuz-client/src/client/album.rs
+++ b/qobuz-client/src/client/album.rs
@@ -70,10 +70,11 @@ impl Album {
         self.tracks.as_ref().map(|t| {
             t.items
                 .iter()
-                .map(|t| {
+                .enumerate()
+                .map(|(i, t)| {
                     TrackListTrack::new(
                         t.clone(),
-                        Some(t.track_number as usize),
+                        Some(i),
                         Some(self.tracks_count as usize),
                         Some(quality.clone()),
                         Some(self.clone()),

--- a/qobuz-client/src/client/album.rs
+++ b/qobuz-client/src/client/album.rs
@@ -1,3 +1,5 @@
+use std::collections::VecDeque;
+
 use crate::client::{
     api::Client,
     artist::{Artist, OtherArtists},
@@ -64,7 +66,7 @@ pub struct Album {
 }
 
 impl Album {
-    pub fn to_tracklist(&self, quality: AudioQuality) -> Option<Vec<TrackListTrack>> {
+    pub fn to_tracklist(&self, quality: AudioQuality) -> Option<VecDeque<TrackListTrack>> {
         self.tracks.as_ref().map(|t| {
             t.items
                 .iter()
@@ -77,10 +79,11 @@ impl Album {
                         Some(self.clone()),
                     )
                 })
-                .collect::<Vec<TrackListTrack>>()
+                .collect::<VecDeque<TrackListTrack>>()
         })
     }
     pub async fn attach_tracks(&mut self, client: Client) {
+        debug!("attaching tracks to album");
         if let Ok(album) = client.album(self.id.clone()).await {
             self.tracks = album.tracks;
         }

--- a/qobuz-client/src/client/api.rs
+++ b/qobuz-client/src/client/api.rs
@@ -723,7 +723,7 @@ impl Client {
         let play_url = "https://play.qobuz.com";
         let login_page = self
             .client
-            .get(format!("{}/login", play_url))
+            .get(format!("{play_url}/login"))
             .send()
             .await
             .expect("failed to get login page. something is very wrong.");
@@ -737,7 +737,7 @@ impl Client {
             .get(1)
             .map_or("", |m| m.as_str());
 
-        let bundle_url = format!("{}{}", play_url, bundle_path);
+        let bundle_url = format!("{play_url}{bundle_path}");
         let bundle_page = self.client.get(bundle_url).send().await.unwrap();
 
         let bundle_contents = bundle_page.text().await.unwrap();
@@ -765,7 +765,7 @@ impl Client {
                         let info = c.name("info").map_or("", |m| m.as_str()).to_string();
                         let extras = c.name("extras").map_or("", |m| m.as_str()).to_string();
 
-                        let chars = format!("{}{}{}", seed, info, extras);
+                        let chars = format!("{seed}{info}{extras}");
                         let encoded_secret = chars[..chars.len() - 44].to_string();
                         let decoded_secret =
                             base64::decode(encoded_secret).expect("failed to decode base64 secret");

--- a/qobuz-client/src/client/api.rs
+++ b/qobuz-client/src/client/api.rs
@@ -299,12 +299,13 @@ impl Client {
     }
 
     /// Retrieve a playlist
-    pub async fn playlist(&self, playlist_id: String) -> Result<Playlist> {
+    pub async fn playlist(&self, playlist_id: i64) -> Result<Playlist> {
         let endpoint = format!("{}{}", self.base_url, Endpoint::Playlist.as_str());
+        let id_string = playlist_id.to_string();
         let params = vec![
             ("limit", "500"),
             ("extra", "tracks"),
-            ("playlist_id", playlist_id.as_str()),
+            ("playlist_id", id_string.as_str()),
             ("offset", "0"),
         ];
         let playlist: Result<Playlist> = get!(self, endpoint.clone(), Some(params.clone()));

--- a/qobuz-client/src/client/mod.rs
+++ b/qobuz-client/src/client/mod.rs
@@ -55,7 +55,7 @@ pub struct User {
 
 pub enum UrlType {
     Album { id: String },
-    Playlist { id: String },
+    Playlist { id: i64 },
 }
 
 /// The audio quality as defined by the Qobuz API.
@@ -102,7 +102,11 @@ pub fn parse_url(string_url: &str) -> Option<UrlType> {
                     }
                     Some("playlist") => {
                         debug!("this is a playlist");
-                        let id = path.next().unwrap().to_string();
+                        let id = path
+                            .next()
+                            .unwrap()
+                            .parse::<i64>()
+                            .expect("failed to convert id");
 
                         Some(UrlType::Playlist { id })
                     }

--- a/qobuz-client/src/client/playlist.rs
+++ b/qobuz-client/src/client/playlist.rs
@@ -1,3 +1,5 @@
+use std::collections::VecDeque;
+
 use crate::client::{
     track::{TrackListTrack, Tracks},
     AudioQuality, User,
@@ -76,7 +78,10 @@ impl Playlist {
         }
     }
 
-    pub fn to_tracklist(&mut self, quality: Option<AudioQuality>) -> Option<Vec<TrackListTrack>> {
+    pub fn to_tracklist(
+        &mut self,
+        quality: Option<AudioQuality>,
+    ) -> Option<VecDeque<TrackListTrack>> {
         self.tracks.as_ref().map(|tracks| {
             tracks
                 .items
@@ -92,7 +97,7 @@ impl Playlist {
                         None,
                     )
                 })
-                .collect::<Vec<TrackListTrack>>()
+                .collect::<VecDeque<TrackListTrack>>()
         })
     }
 }

--- a/qobuz-client/src/client/snapshots/qobuz_client__client__api__can_use_methods.snap.new
+++ b/qobuz-client/src/client/snapshots/qobuz_client__client__api__can_use_methods.snap.new
@@ -1,0 +1,122 @@
+---
+source: qobuz-client/src/client/api.rs
+assertion_line: 856
+expression: "client.user_playlists().await.expect(\"failed to fetch user playlists\")"
+---
+user:
+  id: "[id]"
+  login: "[login]"
+playlists:
+  offset: 0
+  limit: 500
+  total: 3
+  items:
+    - owner:
+        id: 1418967
+        name: David
+      users_count: 0
+      images150: ~
+      images: []
+      is_collaborative: false
+      is_published: false
+      description: This is a description
+      created_at: 1664568712
+      images300: ~
+      duration: 0
+      updated_at: 1664568712
+      published_to: ~
+      tracks_count: 0
+      name: test
+      is_public: false
+      published_from: ~
+      id: 11461926
+      is_featured: false
+      position: 0
+      image_rectangle_mini: []
+      timestamp_position: ~
+      image_rectangle: []
+      slug: test-27
+      stores: []
+      tracks: ~
+    - owner:
+        id: 1418967
+        name: David
+      users_count: 0
+      images150:
+        - "https://static.qobuz.com/images/covers/62/88/0000881118862_150.jpg"
+        - "https://static.qobuz.com/images/covers/34/25/0088807202534_150.jpg"
+        - "https://static.qobuz.com/images/covers/pc/8a/cvv2e35988apc_150.jpg"
+        - "https://static.qobuz.com/images/covers/ca/68/tnmluv61b68ca_150.jpg"
+      images:
+        - "https://static.qobuz.com/images/covers/62/88/0000881118862_50.jpg"
+        - "https://static.qobuz.com/images/covers/34/25/0088807202534_50.jpg"
+        - "https://static.qobuz.com/images/covers/pc/8a/cvv2e35988apc_50.jpg"
+        - "https://static.qobuz.com/images/covers/ca/68/tnmluv61b68ca_50.jpg"
+      is_collaborative: false
+      is_published: false
+      description: "Playlist converted by Soundiiz from another music platform ! https://soundiiz.com"
+      created_at: 1596246958
+      images300:
+        - "https://static.qobuz.com/images/covers/62/88/0000881118862_300.jpg"
+        - "https://static.qobuz.com/images/covers/34/25/0088807202534_300.jpg"
+        - "https://static.qobuz.com/images/covers/pc/8a/cvv2e35988apc_300.jpg"
+        - "https://static.qobuz.com/images/covers/ca/68/tnmluv61b68ca_300.jpg"
+      duration: 321080
+      updated_at: 1673474046
+      published_to: ~
+      tracks_count: 956
+      name: Assignments
+      is_public: true
+      published_from: ~
+      id: 3551270
+      is_featured: false
+      position: 0
+      image_rectangle_mini: []
+      timestamp_position: ~
+      image_rectangle: []
+      slug: assignments
+      stores: []
+      tracks: ~
+    - owner:
+        id: 922179
+        name: Qobuz USA
+      users_count: 375435
+      images150:
+        - "https://static.qobuz.com/images/covers/32/10/0603497941032_150.jpg"
+        - "https://static.qobuz.com/images/covers/89/21/0060255732189_150.jpg"
+        - "https://static.qobuz.com/images/covers/95/15/0060253771595_150.jpg"
+        - "https://static.qobuz.com/images/covers/mb/zg/q64kzhpj3zgmb_150.jpg"
+      images:
+        - "https://static.qobuz.com/images/covers/32/10/0603497941032_50.jpg"
+        - "https://static.qobuz.com/images/covers/89/21/0060255732189_50.jpg"
+        - "https://static.qobuz.com/images/covers/95/15/0060253771595_50.jpg"
+        - "https://static.qobuz.com/images/covers/mb/zg/q64kzhpj3zgmb_50.jpg"
+      is_collaborative: false
+      is_published: true
+      description: New to Qobuz? Wondering what all the fuss is about? Check out this carefully-constructed playlist designed to give you a taste of Qobuz and that famous high fidelity sound. An eclectic selection put together by our team in which no genre gets left behind.
+      created_at: 1567000847
+      images300:
+        - "https://static.qobuz.com/images/covers/32/10/0603497941032_300.jpg"
+        - "https://static.qobuz.com/images/covers/89/21/0060255732189_300.jpg"
+        - "https://static.qobuz.com/images/covers/95/15/0060253771595_300.jpg"
+        - "https://static.qobuz.com/images/covers/mb/zg/q64kzhpj3zgmb_300.jpg"
+      duration: 14912
+      updated_at: 1674686278
+      published_to: 2145913200
+      tracks_count: 53
+      name: Welcome to Qobuz
+      is_public: true
+      published_from: 1293836400
+      id: 2418316
+      is_featured: true
+      position: 0
+      image_rectangle_mini:
+        - "https://static.qobuz.com/images/playlists/2418316_011beec2fea38eddd01675a0ff653ea6_rectangle_mini.jpg"
+      timestamp_position: 1293836400
+      image_rectangle:
+        - "https://static.qobuz.com/images/playlists/2418316_011beec2fea38eddd01675a0ff653ea6_rectangle.jpg"
+      slug: welcome-to-qobuz-1
+      stores:
+        - US-en
+      tracks: ~
+

--- a/qobuz-client/src/client/track.rs
+++ b/qobuz-client/src/client/track.rs
@@ -125,16 +125,15 @@ impl TrackListTrack {
         };
 
         vec![
-            self.index.to_string(),
+            self.track.track_number.to_string(),
             self.track.title.clone(),
             performer,
             duration,
         ]
     }
 
-    pub fn set_track_url(&mut self, track_url: TrackURL) -> Self {
+    pub fn set_track_url(&mut self, track_url: TrackURL) {
         self.track_url = Some(track_url);
-        self.clone()
     }
 }
 

--- a/qobuz-client/src/client/track.rs
+++ b/qobuz-client/src/client/track.rs
@@ -1,7 +1,6 @@
+use crate::client::{album::Album, AudioQuality, TrackURL};
 use gstreamer::ClockTime;
 use serde::{Deserialize, Serialize};
-
-use crate::client::{album::Album, AudioQuality, TrackURL};
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Tracks {
@@ -72,6 +71,14 @@ impl From<Track> for Vec<u8> {
     }
 }
 
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
+pub enum TrackStatus {
+    Played,
+    Playing,
+    #[default]
+    Unplayed,
+}
+
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct TrackListTrack {
     pub track: Track,
@@ -80,6 +87,7 @@ pub struct TrackListTrack {
     pub album: Option<Album>,
     pub index: usize,
     pub total: usize,
+    pub status: TrackStatus,
 }
 
 impl TrackListTrack {
@@ -100,6 +108,7 @@ impl TrackListTrack {
             quality,
             track_url: None,
             album,
+            status: TrackStatus::Unplayed,
         }
     }
 


### PR DESCRIPTION
When switching to sqlite the app performance dropped significantly. This was partly due to the design and just replacing sled with sqlite without much modification.

This work removes sqlite from the player functionality (still used for config) and creates an improved in-memory state. This has increased performance and stability throughout the app.

The next step is to reintroduce sqlite for saving the player state and re-enabling the resume functionality.
