### PR TITLE
Fix mpris position after resume

### DIFF
--- a/.github/workflows/cargo-make.yml
+++ b/.github/workflows/cargo-make.yml
@@ -12,12 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         rust: [stable]
-        include:
-          - os: ubuntu-latest
-            sccache-path: /home/runner/.cache/sccache
-          # - os: macos-latest
-          #   sccache-path: /Users/runner/Library/Caches/Mozilla.sccache
     env:
       RUST_BACKTRACE: full
     steps:
@@ -31,7 +27,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y libunwind-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav gstreamer1.0-tools
-    - name: Install gstreamer & sccache (macos-latest)
+    - name: Install gstreamer (macos-latest)
       if: matrix.os == 'macos-latest'
       run: |
         brew update

--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ I've spent [![n hours](https://wakatime.com/badge/github/iamdb/hifi.rs.svg)](htt
 ### Known Issues
 
 - If left paused for a while, the player will crash when attempting to play again.
-- When resuming and seeking to the spot in the track, mpris does not always update with the correct time. If the player is seeked again the correct time is reported again.
+- When resuming and seeking to the spot in the track, pressing play will cause mpris and the player to go out of sync.
 - UI will freeze during loading of long lists.

--- a/hifirs/src/state/app.rs
+++ b/hifirs/src/state/app.rs
@@ -4,7 +4,7 @@ use crate::{
     ui::components::{Row, TableRows},
 };
 use futures::executor;
-use gstreamer::ClockTime;
+use gstreamer::{ClockTime, State as GstState};
 use qobuz_client::client::{
     album::Album,
     api::Client,
@@ -48,6 +48,7 @@ pub struct PlayerState {
     status: StatusValue,
     is_buffering: bool,
     resume: bool,
+    target_status: StatusValue,
     active_screen: ActiveScreen,
     quit_sender: BroadcastSender<bool>,
 }
@@ -139,6 +140,10 @@ impl PlayerState {
         self.resume = resume;
     }
 
+    pub fn resume(&self) -> bool {
+        self.resume
+    }
+
     pub fn set_current_progress(&mut self, progress: FloatValue) {
         self.current_progress = progress;
     }
@@ -202,6 +207,14 @@ impl PlayerState {
 
     pub fn set_track_status(&mut self, track_id: usize, status: TrackStatus) {
         self.tracklist.set_track_status(track_id, status);
+    }
+
+    pub fn target_status(&self) -> StatusValue {
+        self.target_status.clone()
+    }
+
+    pub fn set_target_status(&mut self, target: GstState) {
+        self.target_status = target.into();
     }
 
     pub fn rows(&self) -> Vec<Row> {
@@ -326,6 +339,7 @@ impl PlayerState {
             duration: ClockValue::default(),
             position: ClockValue::default(),
             status: StatusValue(gstreamer::State::Null),
+            target_status: StatusValue(gstreamer::State::Null),
             current_progress: FloatValue(0.0),
             is_buffering: false,
             resume: false,

--- a/hifirs/src/ui/mod.rs
+++ b/hifirs/src/ui/mod.rs
@@ -50,6 +50,7 @@ pub struct Tui {
     terminal: Console,
     screens: HashMap<ActiveScreen, Arc<Mutex<dyn Screen>>>,
     state: SafePlayerState,
+    controls: Controls,
 }
 
 type Console = Terminal<TermionBackend<AlternateScreen<MouseTerminal<RawTerminal<Stdout>>>>>;
@@ -139,6 +140,7 @@ pub async fn new(
         terminal,
         tx,
         screens,
+        controls,
     };
 
     if let Some(results) = search_results {
@@ -231,6 +233,15 @@ impl Tui {
                 self.render().await;
             }
             Event::Key(key) => match key {
+                Key::Char(' ') => {
+                    self.controls.play_pause().await;
+                }
+                Key::Char('N') => {
+                    self.controls.next().await;
+                }
+                Key::Char('P') => {
+                    self.controls.previous().await;
+                }
                 Key::Char('\t') => {
                     let mut state = self.state.lock().await;
                     let active_screen = state.active_screen();

--- a/hifirs/src/ui/nowplaying.rs
+++ b/hifirs/src/ui/nowplaying.rs
@@ -140,20 +140,8 @@ impl Screen for NowPlayingScreen {
                     Some(())
                 }
             }
-            Key::Char(c) => match c {
-                ' ' => {
-                    self.controls.play_pause().await;
-                    Some(())
-                }
-                'N' => {
-                    self.controls.next().await;
-                    Some(())
-                }
-                'P' => {
-                    self.controls.previous().await;
-                    Some(())
-                }
-                '\n' => {
+            Key::Char(c) => {
+                if let '\n' = c {
                     if let Some(selection) = self.track_list.selected() {
                         if let Some(state) = &self.state {
                             if let Some(current_index) = state.current_track_index() {
@@ -182,9 +170,10 @@ impl Screen for NowPlayingScreen {
                     }
 
                     Some(())
+                } else {
+                    None
                 }
-                _ => None,
-            },
+            }
 
             _ => None,
         }

--- a/qobuz-client/src/client/api.rs
+++ b/qobuz-client/src/client/api.rs
@@ -864,16 +864,20 @@ async fn can_use_methods() {
     .expect("failed to search for albums"),
     {
         ".albums.total" => "0",
-        ".albums.items[].artist.albums_count" => "0"
+        ".albums.items[].artist.albums_count" => "0",
+        ".albums.items[].purchasable_at" => "0"
     });
     assert_yaml_snapshot!(client
         .album("lhrak0dpdxcbc".to_string())
         .await
         .expect("failed to get album"));
     assert_yaml_snapshot!(client
-        .search_artists("pink floyd".to_string(), Some(10))
-        .await
-        .expect("failed to search artists"));
+    .search_artists("pink floyd".to_string(), Some(10))
+    .await
+    .expect("failed to search artists"),
+    {
+        ".artists.items[].albums_count" => "0"
+    });
     assert_yaml_snapshot!(client
         .artist(148745, Some(10))
         .await

--- a/qobuz-client/src/client/snapshots/qobuz_client__client__api__can_use_methods-2.snap
+++ b/qobuz-client/src/client/snapshots/qobuz_client__client__api__can_use_methods-2.snap
@@ -65,7 +65,7 @@ albums:
       product_type: ~
       product_url: ~
       purchasable: true
-      purchasable_at: 1674288000
+      purchasable_at: "0"
       qobuz_id: 9883169
       recording_information: ~
       relative_url: ~
@@ -143,7 +143,7 @@ albums:
       product_type: ~
       product_url: ~
       purchasable: true
-      purchasable_at: 1672128000
+      purchasable_at: "0"
       qobuz_id: 135238664
       recording_information: ~
       relative_url: ~
@@ -221,7 +221,7 @@ albums:
       product_type: ~
       product_url: ~
       purchasable: true
-      purchasable_at: 1674633600
+      purchasable_at: "0"
       qobuz_id: 28265362
       recording_information: ~
       relative_url: ~
@@ -299,7 +299,7 @@ albums:
       product_type: ~
       product_url: ~
       purchasable: true
-      purchasable_at: 1650265200
+      purchasable_at: "0"
       qobuz_id: 23624502
       recording_information: ~
       relative_url: ~
@@ -381,7 +381,7 @@ albums:
       product_type: ~
       product_url: ~
       purchasable: true
-      purchasable_at: 1674201600
+      purchasable_at: "0"
       qobuz_id: 33439043
       recording_information: ~
       relative_url: ~
@@ -459,7 +459,7 @@ albums:
       product_type: ~
       product_url: ~
       purchasable: true
-      purchasable_at: 1634022000
+      purchasable_at: "0"
       qobuz_id: 134816229
       recording_information: ~
       relative_url: ~
@@ -537,7 +537,7 @@ albums:
       product_type: ~
       product_url: ~
       purchasable: true
-      purchasable_at: 1657695600
+      purchasable_at: "0"
       qobuz_id: 15389780
       recording_information: ~
       relative_url: ~
@@ -619,7 +619,7 @@ albums:
       product_type: ~
       product_url: ~
       purchasable: true
-      purchasable_at: 1654758000
+      purchasable_at: "0"
       qobuz_id: 28830019
       recording_information: ~
       relative_url: ~
@@ -698,7 +698,7 @@ albums:
       product_type: ~
       product_url: ~
       purchasable: true
-      purchasable_at: 1671868800
+      purchasable_at: "0"
       qobuz_id: 32496951
       recording_information: ~
       relative_url: ~
@@ -777,7 +777,7 @@ albums:
       product_type: ~
       product_url: ~
       purchasable: true
-      purchasable_at: 1646640000
+      purchasable_at: "0"
       qobuz_id: 126078305
       recording_information: ~
       relative_url: ~

--- a/qobuz-client/src/client/snapshots/qobuz_client__client__api__can_use_methods-4.snap
+++ b/qobuz-client/src/client/snapshots/qobuz_client__client__api__can_use_methods-4.snap
@@ -15,7 +15,7 @@ artists:
         back: ~
       name: Pink Floyd
       id: 38324
-      albums_count: 249
+      albums_count: "0"
       slug: pink-floyd
       albums: ~
     - image:
@@ -25,55 +25,55 @@ artists:
         back: ~
       name: The Australian Pink Floyd Show
       id: 3778014
-      albums_count: 2
+      albums_count: "0"
       slug: theaustralianpinkfloydshow-10003778014
       albums: ~
     - image: ~
       name: Pink Floyd Floydhead
       id: 5661969
-      albums_count: 1
+      albums_count: "0"
       slug: pink-floyd-floydhead
       albums: ~
     - image: ~
       name: The Machine Perform Pink Floyd
       id: 5446149
-      albums_count: 3
+      albums_count: "0"
       slug: the-machine-perform-pink-floyd
       albums: ~
     - image: ~
       name: Celtic Pink Floyd
       id: 5239316
-      albums_count: 3
+      albums_count: "0"
       slug: celtic-pink-floyd
       albums: ~
     - image: ~
       name: The Pink Floyd Story
       id: 3735065
-      albums_count: 3
+      albums_count: "0"
       slug: thepinkfloydstory-10003735065
       albums: ~
     - image: ~
       name: Pink Floyd Redux
       id: 2761835
-      albums_count: 2
+      albums_count: "0"
       slug: pink-floyd-redux
       albums: ~
     - image: ~
       name: Hungarian Pink Floyd Show
       id: 2519235
-      albums_count: 1
+      albums_count: "0"
       slug: hungarian-pink-floyd-show
       albums: ~
     - image: ~
       name: Pink Floyd History
       id: 5636687
-      albums_count: 1
+      albums_count: "0"
       slug: pink-floyd-history
       albums: ~
     - image: ~
       name: A Fair Forgery of Pink Floyd (Various Artists)
       id: 4898001
-      albums_count: 2
+      albums_count: "0"
       slug: a-fair-forgery-of-pink-floyd-various-artists
       albums: ~
 


### PR DESCRIPTION
The mpris position does not update when resuming playback after quit. This fixes that. There is still a small issue where when you press play after it may become slightly out of sync with the actual time until the track changes or the current one skipped in any direction.

- fixes mpris so the position is correct after resume
- removes unneeded pieces from gh action
- updates readme with new info
- moves player controls (play/pause, next, previous) to the main key event loop so it works on all screens