### PR TITLE
stability fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Qobuz only supports Linux through the browser and has no officially supported AP
 
 ## Player Features
 
-- Very low resource usage
-- [GStreamer](https://gstreamer.freedesktop.org/)-backed player, SQLite database
+- Low resource usage
+- [GStreamer](https://gstreamer.freedesktop.org/)-backed player, [SQLite](https://www.sqlite.org/index.html) database
 - High resolution audio: Supports up to 24bit/192Khz (max quality Qobuz offers)
 - MPRIS support (control via [playerctl](https://github.com/altdesktop/playerctl) or other D-Bus client)
 - Gapless playback
-- Resume previous session
-- TUI can be disabled to use as a headless player controlled via MPRIS
+- Resume last session
+- TUI can be disabled to use as a headless player, controlled via MPRIS
 
 In addition to the player, there is a Spotify to Qobuz playlist sync tool and an incomplete Rust library for the Qobuz API.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Qobuz only supports Linux through the browser and has no officially supported AP
 
 ## Player Features
 
+- Very low resource usage
 - [GStreamer](https://gstreamer.freedesktop.org/)-backed player, SQLite database
 - High resolution audio: Supports up to 24bit/192Khz (max quality Qobuz offers)
 - MPRIS support (control via [playerctl](https://github.com/altdesktop/playerctl) or other D-Bus client)
@@ -39,13 +40,12 @@ In addition to the player, there is a Spotify to Qobuz playlist sync tool and an
 ## Known Issues
 
 - If left paused for a while, the player will crash when attempting to play again
-- When resuming and seeking to the spot in the track, pressing play will cause mpris and the player to go out of sync
-- UI will freeze during loading of long lists and then works fine. The issue is there is no feedback alerting the user that something is happening in the background and signifying it is normal behavior.
+- UI will freeze during loading of long lists and then works fine. The issue is there is no feedback alerting the user that something is happening in the background and signifying it is normal behavior. Probably best solved when switching to Cursive.
 
 ## Todo
 
 - Build binaries and make Github releases
 - Use unified search endpoint instead of individual
+- Switch to [Cursive](https://crates.io/crates/cursive) for UI library
 - Enable searching for albums, tracks and playlists in the UI
 - Sortable lists
-- Switch to [Cursive](https://crates.io/crates/cursive) for UI library

--- a/hifirs/src/cli.rs
+++ b/hifirs/src/cli.rs
@@ -226,6 +226,7 @@ pub async fn run() -> Result<(), Error> {
             }
             Ok(())
         }
+        #[allow(unused_variables)]
         Commands::Search {
             query,
             limit,

--- a/hifirs/src/cli.rs
+++ b/hifirs/src/cli.rs
@@ -325,7 +325,7 @@ pub async fn run() -> Result<(), Error> {
 
                     let state = player.state();
 
-                    switch_screen!(state.lock().await, ActiveScreen::Playlists);
+                    switch_screen!(state.write().await, ActiveScreen::Playlists);
                     tui.event_loop().await?;
                 }
             }
@@ -384,7 +384,7 @@ pub async fn run() -> Result<(), Error> {
                     ui::new(player.state(), player.controls(), client, None, None).await?;
 
                 let state = player.state();
-                switch_screen!(state.lock().await, ActiveScreen::NowPlaying);
+                switch_screen!(state.write().await, ActiveScreen::NowPlaying);
 
                 tui.event_loop().await?;
             }
@@ -448,11 +448,11 @@ pub async fn run() -> Result<(), Error> {
 #[macro_export]
 macro_rules! wait {
     ($state:expr) => {
-        let mut quitter = $state.lock().await.quitter();
+        let mut quitter = $state.read().await.quitter();
 
         let state = $state.clone();
         ctrlc::set_handler(move || {
-            state.blocking_lock().quit();
+            state.blocking_read().quit();
             std::process::exit(0);
         })
         .expect("error setting ctrlc handler");

--- a/hifirs/src/mpris.rs
+++ b/hifirs/src/mpris.rs
@@ -111,7 +111,7 @@ impl MprisPlayer {
     }
     #[dbus_interface(property, name = "PlaybackStatus")]
     async fn playback_status(&self) -> &'static str {
-        self.state.lock().await.status().as_str()
+        self.state.read().await.status().as_str()
     }
     #[dbus_interface(property, name = "LoopStatus")]
     fn loop_status(&self) -> &'static str {
@@ -128,7 +128,7 @@ impl MprisPlayer {
     #[dbus_interface(property, name = "Metadata")]
     async fn metadata(&self) -> HashMap<&'static str, zvariant::Value> {
         debug!("dbus metadata");
-        if let Some(next_up) = self.state.lock().await.current_track() {
+        if let Some(next_up) = self.state.read().await.current_track() {
             track_to_meta(next_up)
         } else {
             HashMap::new()
@@ -141,7 +141,7 @@ impl MprisPlayer {
     #[dbus_interface(property, name = "Position")]
     async fn position(&self) -> i64 {
         self.state
-            .lock()
+            .read()
             .await
             .position()
             .inner_clocktime()
@@ -205,7 +205,7 @@ impl MprisTrackList {
         tracks: Vec<String>,
     ) -> Vec<HashMap<&'static str, zvariant::Value>> {
         self.state
-            .lock()
+            .read()
             .await
             .unplayed_tracks()
             .into_iter()
@@ -232,7 +232,7 @@ impl MprisTrackList {
     #[dbus_interface(property, name = "Tracks")]
     async fn tracks(&self) -> Vec<String> {
         self.state
-            .lock()
+            .read()
             .await
             .unplayed_tracks()
             .iter()

--- a/hifirs/src/player.rs
+++ b/hifirs/src/player.rs
@@ -664,6 +664,9 @@ impl Player {
                     match msg.view() {
                         MessageView::Eos(_) => {
                             debug!("END OF STREAM");
+
+                            self.stop(true).await?;
+
                             if self.quit_when_done {
                                 self.state.lock().await.quit();
                             }

--- a/hifirs/src/state/app.rs
+++ b/hifirs/src/state/app.rs
@@ -359,8 +359,16 @@ impl PlayerState {
                             let position =
                                 ClockTime::from_mseconds(last_state.playback_position as u64);
 
-                            let remaining = duration - position;
-                            let progress = position.seconds() as f64 / duration.seconds() as f64;
+                            let remaining = if duration > position {
+                                duration - position
+                            } else {
+                                ClockTime::default()
+                            };
+                            let progress = if duration > position {
+                                position.seconds() as f64 / duration.seconds() as f64
+                            } else {
+                                0.0
+                            };
 
                             self.set_position(position.into());
                             self.set_duration(duration.into());

--- a/hifirs/src/state/app.rs
+++ b/hifirs/src/state/app.rs
@@ -15,7 +15,7 @@ use qobuz_client::client::{
 use std::{fmt::Display, sync::Arc};
 use tokio::sync::{
     broadcast::{Receiver as BroadcastReceiver, Sender as BroadcastSender},
-    Mutex,
+    RwLock,
 };
 
 #[derive(Debug, Clone)]
@@ -36,7 +36,7 @@ pub struct PlayerState {
     quit_sender: BroadcastSender<bool>,
 }
 
-pub type SafePlayerState = Arc<Mutex<PlayerState>>;
+pub type SafePlayerState = Arc<RwLock<PlayerState>>;
 
 #[derive(Debug, Clone, Default)]
 pub struct SavedState {

--- a/hifirs/src/ui/components/player.rs
+++ b/hifirs/src/ui/components/player.rs
@@ -30,13 +30,8 @@ pub(crate) fn progress<B>(
     } else if duration.inner_clocktime() > ClockTime::default() {
         let position = position.to_string().as_str()[2..7].to_string();
         let duration = duration.to_string().as_str()[2..7].to_string();
-        let prog = if progress >= FloatValue(0.0) {
-            progress
-        } else {
-            FloatValue(0.0)
-        };
 
-        let progress = Gauge::default()
+        let prog = Gauge::default()
             .label(format!("{position} / {duration}"))
             .use_unicode(true)
             .block(Block::default().style(Style::default().bg(Color::Indexed(236))))
@@ -46,8 +41,8 @@ pub(crate) fn progress<B>(
                     .fg(Color::Indexed(38))
                     .add_modifier(Modifier::BOLD),
             )
-            .ratio(prog.into());
-        f.render_widget(progress, area);
+            .ratio(progress.into());
+        f.render_widget(prog, area);
     } else {
         let text = "LOADING";
         let loading = Paragraph::new(text)

--- a/hifirs/src/ui/mod.rs
+++ b/hifirs/src/ui/mod.rs
@@ -142,7 +142,7 @@ pub async fn new(
     };
 
     if let Some(results) = search_results {
-        let mut state = state.lock().await;
+        let mut state = state.write().await;
 
         match results {
             SearchResults::UserPlaylists(_) => {
@@ -164,7 +164,7 @@ impl Tui {
         }
     }
     async fn render(&mut self) {
-        let state = self.state.lock().await.clone();
+        let state = self.state.read().await.clone();
         let screen = state.active_screen();
 
         if let Some(screen) = self.screens.get(&screen) {
@@ -207,7 +207,7 @@ impl Tui {
 
         let event_receiver = self.rx.clone();
         let mut event_stream = event_receiver.stream();
-        let mut quitter = self.state.lock().await.quitter();
+        let mut quitter = self.state.read().await.quitter();
 
         loop {
             select! {
@@ -232,7 +232,7 @@ impl Tui {
             }
             Event::Key(key) => match key {
                 Key::Char('\t') => {
-                    let mut state = self.state.lock().await;
+                    let mut state = self.state.write().await;
                     let active_screen = state.active_screen();
 
                     match active_screen {
@@ -252,10 +252,10 @@ impl Tui {
                 }
                 Key::Ctrl('c') | Key::Ctrl('q') => {
                     debug!("quitting ui handle event loop");
-                    self.state.lock().await.quit();
+                    self.state.read().await.quit();
                 }
                 _ => {
-                    if let Some(screen) = self.screens.get(&self.state.lock().await.active_screen())
+                    if let Some(screen) = self.screens.get(&self.state.read().await.active_screen())
                     {
                         if screen.lock().await.key_events(key).await.is_some() {
                             self.tick().await;


### PR DESCRIPTION
- mpris time does not drift
- update readme
- change mutex to rwlock for a perf bump
- switch playbin to playbin3
- switch to using playbin3's instant-uri prop
- adding logic to jumping forward and backward so it returns if the player is buffering to prevent overloading
- set player to ready at end of stream even if not quitting