### PR TITLE
fix bug with gapless playback

### DIFF
--- a/hifirs/src/player.rs
+++ b/hifirs/src/player.rs
@@ -436,7 +436,6 @@ impl Player {
     pub async fn play_track(&self, track: Track, quality: Option<AudioQuality>) -> Result<()> {
         if self.is_playing() {
             self.ready(true).await?;
-            self.playbin.set_property("instant-uri", true);
         }
 
         let quality = if let Some(quality) = quality {
@@ -466,7 +465,6 @@ impl Player {
     pub async fn play_album(&self, mut album: Album, quality: Option<AudioQuality>) -> Result<()> {
         if self.is_playing() || self.is_paused() {
             self.ready(true).await?;
-            self.playbin.set_property("instant-uri", true);
         }
 
         if album.tracks.is_none() {
@@ -554,7 +552,6 @@ impl Player {
     ) -> Result<()> {
         if self.is_playing() || self.is_paused() {
             self.ready(true).await?;
-            self.playbin.set_property("instant-uri", true);
         }
 
         let quality = if let Some(quality) = quality {


### PR DESCRIPTION
There is a `set_property` call in the `play_album`, `play_track` and `play_playlist` methods that tells the player to immediately start playing the next track. It was code from a previous attempt at fixing another issue.
