### PR TITLE
Fix issues with playback and resume for playlists and tracks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,9 +962,9 @@ dependencies = [
 
 [[package]]
 name = "gio-sys"
-version = "0.17.0"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5d3076ecb86c8c3a672c9843d6232b3a344fb81d304d0ba1ac64b23343efa46"
+checksum = "6b1d43b0d7968b48455244ecafe41192871257f5740aa6b095eb19db78e362a5"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -988,9 +988,9 @@ dependencies = [
 
 [[package]]
 name = "glib"
-version = "0.17.3"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ce6595f2fb74b90d15680d5c2d84cf89ca03c8ff96dcd8f4a8a6c214e629b3"
+checksum = "9edf60b1aa961c0ce2b824f77e76a0179f04a566fd8481ae68adbac642d4f809"
 dependencies = [
  "bitflags",
  "futures-channel",
@@ -1011,9 +1011,9 @@ dependencies = [
 
 [[package]]
 name = "glib-macros"
-version = "0.17.3"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5281157383168967254909b5f9973bc6bbfcc958760719a79a6b334689d6de3"
+checksum = "5573c92a7b942b4a577ee62bf22eebeeb2327a5df3394d3a2130c969597b251d"
 dependencies = [
  "anyhow",
  "heck",
@@ -1026,9 +1026,9 @@ dependencies = [
 
 [[package]]
 name = "glib-sys"
-version = "0.17.2"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a0985cf568e18cf63b443c9a14f4bdaa947fed7437476000dba84926a20b25"
+checksum = "49f00ad0a1bf548e61adfff15d83430941d9e1bb620e334f779edd1c745680a5"
 dependencies = [
  "libc",
  "system-deps",
@@ -1036,9 +1036,9 @@ dependencies = [
 
 [[package]]
 name = "gobject-sys"
-version = "0.17.0"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a0155d388840c77d61b033b66ef4f9bc7f4133d83df83572d6b4fb234a3be7d"
+checksum = "15e75b0000a64632b2d8ca3cf856af9308e3a970844f6e9659bd197f026793d0"
 dependencies = [
  "glib-sys",
  "libc",
@@ -1047,9 +1047,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer"
-version = "0.20.2"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d4f183660dc65a607f9c97ce4a3f72a208bf888c0c34d6cd052c7c4b2e086a1"
+checksum = "4c46cc10a7ab79329feb68bef54a242ced84c3147cc1b81bc5c6140346a1dbf9"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2236,9 +2236,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50686e0021c4136d1d453b2dfe059902278681512a34d4248435dc34b6b5c8ec"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -2592,9 +2592,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.155"
+version = "1.0.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71f2b4817415c6d4210bfe1c7bfcf4801b2d904cb4d0e1a8fdb651013c9e86b8"
+checksum = "314b5b092c0ade17c00142951e50ced110ec27cea304b1037c6969246c2469a4"
 dependencies = [
  "serde_derive",
 ]
@@ -2610,9 +2610,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.155"
+version = "1.0.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d071a94a3fac4aff69d023a7f411e33f40f3483f8c5190b1953822b6b76d7630"
+checksum = "d7e29c4601e36bcec74a223228dce795f4cd3616341a4af93520ca1a837c087d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/hifirs/src/cli.rs
+++ b/hifirs/src/cli.rs
@@ -364,7 +364,7 @@ pub async fn run() -> Result<(), Error> {
         } => {
             let client = qobuz::make_client(cli.username, cli.password, &data).await?;
 
-            let album = client.album(album_id).await?;
+            let album = client.album(&album_id).await?;
 
             let quality = if let Some(q) = quality {
                 q

--- a/hifirs/src/mpris.rs
+++ b/hifirs/src/mpris.rs
@@ -267,6 +267,10 @@ fn track_to_meta(
         ),
     );
 
+    if let Some(artist) = playlist_track.track.performer {
+        meta.insert("xesam:artist", zvariant::Value::new(artist.name));
+    }
+
     if let Some(album) = playlist_track.album {
         meta.insert("mpris:artUrl", zvariant::Value::new(album.image.large));
         meta.insert("xesam:album", zvariant::Value::new(album.title));

--- a/hifirs/src/player.rs
+++ b/hifirs/src/player.rs
@@ -24,7 +24,7 @@ use hifirs_qobuz_api::client::{
     AudioQuality,
 };
 use snafu::prelude::*;
-use std::{process, sync::Arc, time::Duration};
+use std::{collections::VecDeque, process, sync::Arc, time::Duration};
 use tokio::{select, sync::RwLock};
 use zbus::Connection;
 
@@ -447,15 +447,23 @@ impl Player {
             self.client.quality()
         };
 
-        let mut playlist_track =
-            TrackListTrack::new(track, Some(0), Some(1), Some(quality.clone()), None);
+        let mut track = TrackListTrack::new(track, Some(0), Some(1), Some(quality.clone()), None);
+        track.status = TrackStatus::Playing;
+
+        let mut queue = VecDeque::new();
+        queue.push_front(track.clone());
+
+        let mut tracklist = TrackListValue::new(Some(queue));
+        tracklist.set_list_type(TrackListType::Track);
 
         let mut state = self.state.write().await;
-        state.attach_track_url(&mut playlist_track).await;
-        state.set_current_track(playlist_track.clone());
+        state.replace_list(tracklist);
+
+        state.attach_track_url(&mut track).await;
+        state.set_current_track(track.clone());
         state.set_target_status(GstState::Playing);
 
-        if let Some(track_url) = playlist_track.track_url {
+        if let Some(track_url) = track.track_url {
             self.playbin
                 .set_property("uri", Some(track_url.url.to_string()));
 
@@ -547,6 +555,15 @@ impl Player {
                     }
                     Err(err) => {
                         println!("Failed to play playlsit {id}, {err}. Is the ID correct?");
+                        process::exit(1);
+                    }
+                },
+                client::UrlType::Track { id } => match self.client.track(id).await {
+                    Ok(track) => {
+                        self.play_track(track, Some(quality)).await?;
+                    }
+                    Err(err) => {
+                        println!("Failed to play track {id}, {err}. Is the ID correct?");
                         process::exit(1);
                     }
                 },

--- a/hifirs/src/qobuz/mod.rs
+++ b/hifirs/src/qobuz/mod.rs
@@ -71,9 +71,16 @@ pub async fn setup_client(client: &mut Client, db: &Database) -> Result<Client> 
 
             if refresh_config {
                 client.refresh().await?;
-            }
+                client.test_secrets().await?;
 
-            client.test_secrets().await?;
+                if let Some(id) = client.get_app_id() {
+                    db.set_app_id(id).await;
+                }
+
+                if let Some(secret) = client.get_active_secret() {
+                    db.set_active_secret(secret).await;
+                }
+            }
         } else if let (Some(username), Some(password)) = (config.username, config.password) {
             info!("using username and password from cache");
             client.set_credentials(Credentials {
@@ -83,6 +90,10 @@ pub async fn setup_client(client: &mut Client, db: &Database) -> Result<Client> 
 
             if refresh_config {
                 client.refresh().await?;
+
+                if let Some(id) = client.get_app_id() {
+                    db.set_app_id(id).await;
+                }
             }
 
             client.login().await?;
@@ -90,6 +101,10 @@ pub async fn setup_client(client: &mut Client, db: &Database) -> Result<Client> 
 
             if let Some(token) = client.get_token() {
                 db.set_user_token(token).await;
+            }
+
+            if let Some(secret) = client.get_active_secret() {
+                db.set_active_secret(secret).await;
             }
         } else {
             return Err(hifirs_qobuz_api::Error::NoCredentials);

--- a/hifirs/src/state/app.rs
+++ b/hifirs/src/state/app.rs
@@ -384,7 +384,7 @@ impl PlayerState {
 
             match entity_type {
                 TrackListType::Album => {
-                    if let Ok(album) = self.client.album(last_state.playback_entity_id).await {
+                    if let Ok(album) = self.client.album(&last_state.playback_entity_id).await {
                         self.replace_list(TrackListValue::new(
                             album.to_tracklist(AudioQuality::HIFI192),
                         ));

--- a/hifirs/target/sqlx/hifi-rs/query-4e07408562bedb8b60ce05c1decfe3ad16b72230967de01f640b7e4729b49fce.json
+++ b/hifirs/target/sqlx/hifi-rs/query-4e07408562bedb8b60ce05c1decfe3ad16b72230967de01f640b7e4729b49fce.json
@@ -1,0 +1,11 @@
+{
+  "query": "INSERT INTO player_state VALUES(NULL,?1,?2,?3,?4,?5);",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 5
+    },
+    "nullable": []
+  },
+  "hash": "823e42cefeae8136283f6045d5dfed38d076c0cd725928bf7e022c3b27af52fc"
+}

--- a/hifirs/target/sqlx/hifi-rs/query-7902699be42c8a8e46fbbb4501726517e86b22c56a189f7625a6da49081b2451.json
+++ b/hifirs/target/sqlx/hifi-rs/query-7902699be42c8a8e46fbbb4501726517e86b22c56a189f7625a6da49081b2451.json
@@ -1,0 +1,49 @@
+{
+  "query": "SELECT * FROM player_state ORDER BY rowid DESC LIMIT 1;",
+  "describe": {
+    "columns": [
+      {
+        "name": "rowid",
+        "ordinal": 0,
+        "type_info": "Int64"
+      },
+      {
+        "name": "playback_track_id",
+        "ordinal": 1,
+        "type_info": "Int64"
+      },
+      {
+        "name": "playback_position",
+        "ordinal": 2,
+        "type_info": "Int64"
+      },
+      {
+        "name": "playback_track_index",
+        "ordinal": 3,
+        "type_info": "Int64"
+      },
+      {
+        "name": "playback_entity_id",
+        "ordinal": 4,
+        "type_info": "Text"
+      },
+      {
+        "name": "playback_entity_type",
+        "ordinal": 5,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "4f528d52c78b3d778e064369fc36af49ddc8c06bdde609f9579eaf2ea709b6e1"
+}

--- a/qobuz-api/src/client/album.rs
+++ b/qobuz-api/src/client/album.rs
@@ -85,7 +85,7 @@ impl Album {
     }
     pub async fn attach_tracks(&mut self, client: Client) {
         debug!("attaching tracks to album");
-        if let Ok(album) = client.album(self.id.clone()).await {
+        if let Ok(album) = client.album(&self.id).await {
             self.tracks = album.tracks;
         }
     }

--- a/qobuz-api/src/client/api.rs
+++ b/qobuz-api/src/client/api.rs
@@ -462,9 +462,9 @@ impl Client {
     }
 
     // Retrieve information about an album
-    pub async fn album(&self, album_id: String) -> Result<Album> {
+    pub async fn album(&self, album_id: &str) -> Result<Album> {
         let endpoint = format!("{}{}", self.base_url, Endpoint::Album.as_str());
-        let params = vec![("album_id", album_id.as_str())];
+        let params = vec![("album_id", album_id)];
 
         get!(self, endpoint, Some(params))
     }
@@ -793,7 +793,7 @@ async fn can_use_methods() {
         ".albums.items[].purchasable_at" => "0"
     });
     assert_yaml_snapshot!(client
-        .album("lhrak0dpdxcbc".to_string())
+        .album("lhrak0dpdxcbc")
         .await
         .expect("failed to get album"));
     assert_yaml_snapshot!(client

--- a/qobuz-api/src/client/mod.rs
+++ b/qobuz-api/src/client/mod.rs
@@ -57,14 +57,13 @@ pub struct User {
 pub enum UrlType {
     Album { id: String },
     Playlist { id: i64 },
+    Track { id: i32 },
 }
 
 #[derive(Snafu, Debug)]
 pub enum UrlTypeError {
     #[snafu(display("please use URIs from the play.qobuz.domain"))]
     WrongDomain,
-    #[snafu(display("playing a track via URI is not currently supported"))]
-    NoTrack,
     #[snafu(display("the url contains an invalid path"))]
     InvalidPath,
     #[snafu(display("the url is invalid."))]
@@ -127,7 +126,16 @@ pub fn parse_url(string_url: &str) -> ParseUrlResult<UrlType> {
 
                         Ok(UrlType::Playlist { id })
                     }
-                    Some("track") => Err(UrlTypeError::NoTrack),
+                    Some("track") => {
+                        debug!("this is a track");
+                        let id = path
+                            .next()
+                            .unwrap()
+                            .parse::<i32>()
+                            .expect("failed to convert id");
+
+                        Ok(UrlType::Track { id })
+                    }
                     None => {
                         debug!("no path, cannot use path");
                         Err(UrlTypeError::InvalidPath)

--- a/qobuz-api/src/client/mod.rs
+++ b/qobuz-api/src/client/mod.rs
@@ -62,7 +62,7 @@ pub enum UrlType {
 
 #[derive(Snafu, Debug)]
 pub enum UrlTypeError {
-    #[snafu(display("please use URIs from the play.qobuz.domain"))]
+    #[snafu(display("This uri contains an unfamiliar domain."))]
     WrongDomain,
     #[snafu(display("the url contains an invalid path"))]
     InvalidPath,
@@ -106,7 +106,7 @@ impl Display for AudioQuality {
 pub fn parse_url(string_url: &str) -> ParseUrlResult<UrlType> {
     if let Ok(url) = url::Url::parse(string_url) {
         if let (Some(host), Some(mut path)) = (url.host_str(), url.path_segments()) {
-            if host == "play.qobuz.com" {
+            if host == "play.qobuz.com" || host == "open.qobuz.com" {
                 debug!("got a qobuz url");
 
                 match path.next() {


### PR DESCRIPTION
This fixes issues with:

- playing individual tracks via uri
- resuming an individual track
- resuming a playlist
- playing uris from the open.qobuz.com domain
- no artist showing up in mpris when playing a playlist or track

It also has better error messages for failure to play via uri.
