### PR TITLE
allow for 3 digit track/playlist numbers

### DIFF
--- a/hifirs/src/cli.rs
+++ b/hifirs/src/cli.rs
@@ -220,7 +220,7 @@ async fn setup_player<'s>(
 
 pub async fn run() -> Result<(), Error> {
     tracing_subscriber::registry()
-        .with(fmt::layer().compact().pretty())
+        .with(fmt::layer().compact().pretty().with_writer(std::io::stderr))
         .with(EnvFilter::from_env("HIFIRS_LOG"))
         .init();
     //pretty_env_logger::init();

--- a/hifirs/src/cursive/mod.rs
+++ b/hifirs/src/cursive/mod.rs
@@ -108,17 +108,17 @@ impl CursiveUI {
 
         let track_num = LinearLayout::new(Orientation::Vertical)
             .child(
-                TextView::new("00")
-                    .h_align(HAlign::Center)
+                TextView::new("000")
+                    .h_align(HAlign::Left)
                     .with_name("current_track_number"),
             )
             .child(TextView::new("of").h_align(HAlign::Center))
             .child(
-                TextView::new("00")
-                    .h_align(HAlign::Center)
+                TextView::new("000")
+                    .h_align(HAlign::Left)
                     .with_name("total_tracks"),
             )
-            .fixed_width(2);
+            .fixed_width(3);
 
         let player_status = LinearLayout::new(Orientation::Vertical)
             .child(
@@ -575,7 +575,7 @@ fn submit_playlist(
 
             let c = controls;
             let meta = LinearLayout::horizontal()
-                .child(Button::new("play", move |s| {
+                .child(Button::new("play", move |_s| {
                     let c = c.clone();
 
                     block_on(async { c.play_playlist(playlist.id).await });
@@ -740,9 +740,9 @@ pub async fn receive_notifications(cb: CursiveSender, mut receiver: BroadcastRec
                         cb.send(Box::new(move |s| {
                             if let (Some(mut track_num), Some(mut track_title), Some(mut progress)) = (s.find_name::<TextView>("current_track_number"), s.find_name::<TextView>("current_track_title"), s.find_name::<ProgressBar>("progress")) {
                                 if track.album.is_some() {
-                                    track_num.set_content(format!("{:02}", track.track.track_number));
+                                    track_num.set_content(format!("{:03}", track.track.track_number));
                                 } else {
-                                    track_num.set_content(format!("{:02}", track.index));
+                                    track_num.set_content(format!("{:03}", track.index));
                                 }
                                 track_title.set_content(track.track.title.trim());
                                 progress.set_max(track.track.duration as usize);

--- a/hifirs/src/mpris.rs
+++ b/hifirs/src/mpris.rs
@@ -71,7 +71,7 @@ pub async fn receive_notifications(
         select! {
             Ok(notification) = receiver.recv() => {
                 match notification {
-                    Notification::Buffering { is_buffering: _ } => {
+                    Notification::Buffering { is_buffering: _, target_status: _, percent: _ } => {
                         let iface_ref = object_server
                             .interface::<_, MprisPlayer>("/org/mpris/MediaPlayer2")
                             .await
@@ -444,7 +444,7 @@ fn track_to_meta(
         );
     }
 
-    if let Some(album) = playlist_track.album {
+    if let Some(album) = playlist_track.track.album {
         meta.insert("mpris:artUrl", zvariant::Value::new(album.image.large));
         meta.insert(
             "xesam:album",

--- a/hifirs/src/player/notification.rs
+++ b/hifirs/src/player/notification.rs
@@ -10,11 +10,27 @@ pub type BroadcastSender = async_broadcast::Sender<Notification>;
 
 #[derive(Debug, Clone)]
 pub enum Notification {
-    Buffering { is_buffering: bool },
-    Status { status: StatusValue },
-    Position { position: ClockValue },
-    Duration { duration: ClockValue },
-    CurrentTrackList { list: TrackListValue },
-    CurrentTrack { track: TrackListTrack },
-    Error { error: player::error::Error },
+    Buffering {
+        is_buffering: bool,
+        percent: i32,
+        target_status: StatusValue,
+    },
+    Status {
+        status: StatusValue,
+    },
+    Position {
+        position: ClockValue,
+    },
+    Duration {
+        duration: ClockValue,
+    },
+    CurrentTrackList {
+        list: TrackListValue,
+    },
+    CurrentTrack {
+        track: TrackListTrack,
+    },
+    Error {
+        error: player::error::Error,
+    },
 }


### PR DESCRIPTION
This makes room for an extra digit in the player for playlists with over 100 items.

I've also added a fix for the mpris album display, some tweaks to the buffering logic, and show the buffering in the TUI.

fixes #167 
attempts to fix #159