### PR TITLE
Fix freezes when skipping, Adds play by url to UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1534,7 +1534,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hifi-rs"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "async-broadcast",
  "async-trait",

--- a/hifirs/Cargo.toml
+++ b/hifirs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "hifi-rs"
-version = "0.2.3"
+version = "0.2.4"
 license-file = "../LICENSE"
 repository = "https://github.com/iamdb/hifi.rs"
 

--- a/hifirs/src/cli.rs
+++ b/hifirs/src/cli.rs
@@ -223,7 +223,7 @@ async fn setup_player<'s>(
 
 pub async fn run() -> Result<(), Error> {
     tracing_subscriber::registry()
-        .with(fmt::layer().compact().pretty().with_writer(std::io::stderr))
+        .with(fmt::layer().pretty().with_writer(std::io::stderr))
         .with(EnvFilter::from_env("HIFIRS_LOG"))
         .init();
     //pretty_env_logger::init();

--- a/hifirs/src/mpris.rs
+++ b/hifirs/src/mpris.rs
@@ -179,17 +179,9 @@ pub async fn receive_notifications(
 
                         let mut iface = iface_ref.get_mut().await;
 
-                        if track.index == 0 {
-                            iface.can_previous = false;
-                        } else {
-                            iface.can_previous = true;
-                        }
+                        iface.can_previous = track.index != 0;
 
-                        if iface.total_tracks != 0 && track.index == iface.total_tracks - 1 {
-                            iface.can_next = false;
-                        } else {
-                            iface.can_next = true;
-                        }
+                        iface.can_next = !(iface.total_tracks != 0 && track.index == iface.total_tracks - 1);
 
                         iface.total_tracks = track.total;
                         iface.current_track = Some(track);

--- a/hifirs/src/player/mod.rs
+++ b/hifirs/src/player/mod.rs
@@ -778,11 +778,11 @@ pub async fn player_loop(
                         let is_buffering = safe_state.read().await.buffering();
 
                         if percent < 100 && !player.is_paused() && !is_buffering {
-                            player.pause(true).await?;
+                            player.pause(false).await?;
 
                             safe_state.write().await.set_buffering(true);
                         } else if percent > 99 && is_buffering && player.is_paused() {
-                            player.set_player_state(target_status.clone().into(), true).await?;
+                            player.set_player_state(target_status.clone().into(), false).await?;
                             safe_state.write().await.set_buffering(false);
                         }
 

--- a/hifirs/src/state/app.rs
+++ b/hifirs/src/state/app.rs
@@ -370,7 +370,7 @@ impl PlayerState {
         let now = chrono::offset::Local::now().timestamp_millis();
         let last_skip = self.last_skip.timestamp_millis();
 
-        if now - last_skip < 250 {
+        if self.is_buffering || now - last_skip < 500 {
             return None;
         }
 

--- a/hifirs/src/state/app.rs
+++ b/hifirs/src/state/app.rs
@@ -2,7 +2,6 @@ use crate::{
     sql::db::Database,
     state::{ActiveScreen, ClockValue, FloatValue, StatusValue, TrackListType, TrackListValue},
 };
-use chrono::{DateTime, Local};
 use futures::executor;
 use gstreamer::{ClockTime, State as GstState};
 use hifirs_qobuz_api::client::{
@@ -12,12 +11,7 @@ use hifirs_qobuz_api::client::{
     track::{TrackListTrack, TrackStatus},
     AudioQuality,
 };
-use std::{
-    collections::VecDeque,
-    fmt::Display,
-    sync::Arc,
-    time::{Duration, SystemTime},
-};
+use std::{collections::VecDeque, fmt::Display, sync::Arc};
 use tokio::sync::{
     broadcast::{Receiver as BroadcastReceiver, Sender as BroadcastSender},
     RwLock,
@@ -40,9 +34,6 @@ pub struct PlayerState {
     active_screen: ActiveScreen,
     audio_quality: AudioQuality,
     quit_sender: BroadcastSender<bool>,
-    jumps: usize,
-    last_jump: SystemTime,
-    last_skip: DateTime<Local>,
 }
 
 pub type SafePlayerState = Arc<RwLock<PlayerState>>;
@@ -307,25 +298,6 @@ impl PlayerState {
         self.is_live
     }
 
-    pub fn jumps(&self) -> usize {
-        self.jumps
-    }
-
-    pub fn add_jump(&mut self) {
-        self.jumps += 1;
-    }
-
-    pub fn sub_jump(&mut self) {
-        self.jumps -= 1;
-    }
-
-    pub fn check_last_jump(&self) -> bool {
-        self.last_jump
-            .elapsed()
-            .expect("failed to get elapsed time, should not occur")
-            < Duration::from_millis(500)
-    }
-
     /// Attach a `TrackURL` to the given track.
     pub async fn attach_track_url(&mut self, track: &mut TrackListTrack) {
         debug!("fetching track url");
@@ -367,10 +339,7 @@ impl PlayerState {
         index: Option<usize>,
         direction: SkipDirection,
     ) -> Option<TrackListTrack> {
-        let now = chrono::offset::Local::now().timestamp_millis();
-        let last_skip = self.last_skip.timestamp_millis();
-
-        if self.is_buffering || now - last_skip < 500 {
+        if self.is_buffering {
             return None;
         }
 
@@ -425,10 +394,6 @@ impl PlayerState {
                 }
             }
 
-            if current_track.is_some() {
-                self.last_skip = chrono::offset::Local::now();
-            }
-
             current_track
         } else {
             debug!("no more tracks");
@@ -452,14 +417,6 @@ impl PlayerState {
         self.quit_sender
             .send(true)
             .expect("failed to send quit message");
-    }
-
-    pub fn set_last_skip(&mut self, last_skip: DateTime<Local>) {
-        self.last_skip = last_skip;
-    }
-
-    pub fn last_skip(&self) -> DateTime<Local> {
-        self.last_skip
     }
 
     pub fn reset(&mut self) {
@@ -493,9 +450,6 @@ impl PlayerState {
             resume: false,
             active_screen: ActiveScreen::NowPlaying,
             quit_sender,
-            jumps: 0,
-            last_jump: SystemTime::now(),
-            last_skip: chrono::offset::Local::now(),
         }
     }
 


### PR DESCRIPTION
If skipping tracks too quickly or if the format of the tracks change, it seems it can corrupt the pipelines in gstreamer. This readies them first before switching tracks so new pipelines can be used.

An item to the menu has been added to allow users to enter a URL to play.