### PR TITLE
Simplifies the logic behind skipping tracks

### DIFF
--- a/hifirs/src/mpris.rs
+++ b/hifirs/src/mpris.rs
@@ -67,10 +67,13 @@ pub async fn receive_notifications(conn: Connection) {
                 Notification::Quit => {
                     return;
                 }
-                Notification::Loading { is_loading: _ } => {}
+                Notification::Loading {
+                    is_loading: _,
+                    target_state: _,
+                } => {}
                 Notification::Buffering {
                     is_buffering: _,
-                    target_status: _,
+                    target_state: _,
                     percent: _,
                 } => {
                     let iface_ref = object_server

--- a/hifirs/src/player/mod.rs
+++ b/hifirs/src/player/mod.rs
@@ -290,6 +290,13 @@ pub async fn resume(autoplay: bool) -> Result<()> {
                 ready().await?;
                 pause().await?;
 
+                let mut interval = tokio::time::interval(Duration::from_millis(100));
+
+                while !is_paused() {
+                    debug!("wait for paused state");
+                    interval.tick().await;
+                }
+
                 seek(last_position, None).await?;
 
                 return Ok(());

--- a/hifirs/src/player/notification.rs
+++ b/hifirs/src/player/notification.rs
@@ -19,7 +19,7 @@ pub enum Notification {
     Buffering {
         is_buffering: bool,
         percent: u32,
-        target_status: State,
+        target_state: State,
     },
     Status {
         status: State,
@@ -38,6 +38,7 @@ pub enum Notification {
     Quit,
     Loading {
         is_loading: bool,
+        target_state: State,
     },
     Error {
         error: player::error::Error,

--- a/hifirs/src/player/queue/controls.rs
+++ b/hifirs/src/player/queue/controls.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use futures::executor;
 use gstreamer::{ClockTime, State as GstState};
-use std::{collections::BTreeMap, fmt::Display, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc};
 use tokio::sync::{
     broadcast::{Receiver as BroadcastReceiver, Sender as BroadcastSender},
     RwLock,
@@ -165,6 +165,14 @@ impl PlayerState {
         self.current_track.clone()
     }
 
+    pub fn current_track_position(&self) -> u32 {
+        if let Some(track) = &self.current_track {
+            track.position
+        } else {
+            0
+        }
+    }
+
     pub fn unplayed_tracks(&self) -> Vec<&Track> {
         self.tracklist.unplayed_tracks()
     }
@@ -215,69 +223,31 @@ impl PlayerState {
         }
     }
 
-    pub async fn skip_track(
-        &mut self,
-        index: Option<u32>,
-        direction: SkipDirection,
-    ) -> Option<Track> {
-        let next_track_index = if let Some(i) = index {
-            if i <= self.tracklist.total() {
-                Some(i)
-            } else {
-                None
-            }
-        } else if let Some(current_track) = self.current_track() {
-            let current_track_index = current_track.position;
+    pub async fn skip_track(&mut self, index: u32) -> Option<Track> {
+        let mut current_track = None;
 
-            match direction {
-                SkipDirection::Forward => {
-                    if current_track_index < self.tracklist.total() {
-                        Some(current_track_index + 1)
+        for t in self.tracklist.queue.values_mut() {
+            match t.position.cmp(&index) {
+                std::cmp::Ordering::Less => {
+                    t.status = TrackStatus::Played;
+                }
+                std::cmp::Ordering::Equal => {
+                    if let Some(track_url) = self.service.track_url(t.id as i32).await {
+                        t.status = TrackStatus::Playing;
+                        t.track_url = Some(track_url);
+                        self.current_track = Some(t.clone());
+                        current_track = Some(t.clone());
                     } else {
-                        None
+                        t.status = TrackStatus::Unplayable;
                     }
                 }
-                SkipDirection::Backward => {
-                    if current_track_index > 1 {
-                        Some(current_track_index - 1)
-                    } else {
-                        Some(0)
-                    }
+                std::cmp::Ordering::Greater => {
+                    t.status = TrackStatus::Unplayed;
                 }
             }
-        } else {
-            None
-        };
-
-        if let Some(index) = next_track_index {
-            let mut current_track = None;
-
-            for t in self.tracklist.queue.values_mut() {
-                match t.position.cmp(&index) {
-                    std::cmp::Ordering::Less => {
-                        t.status = TrackStatus::Played;
-                    }
-                    std::cmp::Ordering::Equal => {
-                        if let Some(track_url) = self.service.track_url(t.id as i32).await {
-                            t.status = TrackStatus::Playing;
-                            t.track_url = Some(track_url);
-                            self.current_track = Some(t.clone());
-                            current_track = Some(t.clone());
-                        } else {
-                            t.status = TrackStatus::Unplayable;
-                        }
-                    }
-                    std::cmp::Ordering::Greater => {
-                        t.status = TrackStatus::Unplayed;
-                    }
-                }
-            }
-
-            current_track
-        } else {
-            debug!("no more tracks");
-            None
         }
+
+        current_track
     }
 
     pub async fn search_all(&self, query: &str) -> Option<SearchResults> {
@@ -360,11 +330,8 @@ impl PlayerState {
                         self.tracklist.set_list_type(TrackListType::Album);
                         self.tracklist.set_album(album);
 
-                        self.skip_track(
-                            Some(last_state.playback_track_index as u32),
-                            SkipDirection::Forward,
-                        )
-                        .await;
+                        self.skip_track(last_state.playback_track_index as u32)
+                            .await;
 
                         let position =
                             ClockTime::from_mseconds(last_state.playback_position as u64);
@@ -386,11 +353,8 @@ impl PlayerState {
                         self.tracklist.set_list_type(TrackListType::Playlist);
                         self.tracklist.set_playlist(playlist);
 
-                        self.skip_track(
-                            Some(last_state.playback_track_index as u32),
-                            SkipDirection::Forward,
-                        )
-                        .await;
+                        self.skip_track(last_state.playback_track_index as u32)
+                            .await;
 
                         let position =
                             ClockTime::from_mseconds(last_state.playback_position as u64);
@@ -415,11 +379,8 @@ impl PlayerState {
                         self.replace_list(tracklist);
                         self.tracklist.set_list_type(TrackListType::Track);
 
-                        self.skip_track(
-                            Some(last_state.playback_track_index as u32),
-                            SkipDirection::Forward,
-                        )
-                        .await;
+                        self.skip_track(last_state.playback_track_index as u32)
+                            .await;
 
                         let position =
                             ClockTime::from_mseconds(last_state.playback_position as u64);
@@ -431,20 +392,5 @@ impl PlayerState {
         }
 
         None
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SkipDirection {
-    Forward,
-    Backward,
-}
-
-impl Display for SkipDirection {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            SkipDirection::Forward => f.write_str("forward"),
-            SkipDirection::Backward => f.write_str("backward"),
-        }
     }
 }

--- a/hifirs/src/player/queue/controls.rs
+++ b/hifirs/src/player/queue/controls.rs
@@ -223,8 +223,8 @@ impl PlayerState {
         }
     }
 
-    pub async fn skip_track(&mut self, index: u32) -> Option<Track> {
-        let mut current_track = None;
+    pub async fn skip_track(&mut self, index: u32) -> Option<String> {
+        let mut track_url = None;
 
         for t in self.tracklist.queue.values_mut() {
             match t.position.cmp(&index) {
@@ -232,11 +232,11 @@ impl PlayerState {
                     t.status = TrackStatus::Played;
                 }
                 std::cmp::Ordering::Equal => {
-                    if let Some(track_url) = self.service.track_url(t.id as i32).await {
+                    if let Some(url) = self.service.track_url(t.id as i32).await {
                         t.status = TrackStatus::Playing;
-                        t.track_url = Some(track_url);
+                        t.track_url = Some(url.clone());
+                        track_url = Some(url);
                         self.current_track = Some(t.clone());
-                        current_track = Some(t.clone());
                     } else {
                         t.status = TrackStatus::Unplayable;
                     }
@@ -247,7 +247,7 @@ impl PlayerState {
             }
         }
 
-        current_track
+        track_url
     }
 
     pub async fn search_all(&self, query: &str) -> Option<SearchResults> {

--- a/www/src/lib/components/TrackMetadata.svelte
+++ b/www/src/lib/components/TrackMetadata.svelte
@@ -5,7 +5,8 @@
 		numOfTracks,
 		entityTitle,
 		positionString,
-		durationString
+		durationString,
+		position
 	} from '$lib/websocket';
 	import { writable } from 'svelte/store';
 
@@ -20,6 +21,8 @@
 			enableMarquee.set(false);
 		}
 	});
+
+	$: progress = ($position / $currentTrack.durationSeconds) * 100;
 </script>
 
 <div class="flex flex-col items-center">
@@ -38,7 +41,7 @@
 <div
 	bind:offsetWidth={titleWrapperWidth}
 	class:justify-center={!$enableMarquee}
-	class="bg-amber-900 overflow-hidden flex flex-row"
+	class="bg-amber-900 flex flex-row relative"
 >
 	<div
 		class:marquee={$enableMarquee}
@@ -79,6 +82,10 @@
 			{/if}
 		</div>
 	{/if}
+	<div
+		style:width="{progress}%"
+		class="absolute top-full left-0 w-full h-1 bg-blue-600/75 z-50"
+	></div>
 </div>
 
 <div class="flex flex-col gap-y-4 max-w-xs mx-auto">

--- a/www/src/lib/websocket.js
+++ b/www/src/lib/websocket.js
@@ -119,7 +119,7 @@ export class WS {
       if (Object.hasOwn(json, 'buffering')) {
         isBuffering.set(json.buffering.is_buffering);
       } else if (Object.hasOwn(json, 'loading')) {
-        isLoading.set(json.loading.isLoading);
+        isLoading.set(json.loading.is_loading);
       } else if (Object.hasOwn(json, 'position')) {
         position.set(json.position.clock);
       } else if (Object.hasOwn(json, 'duration')) {

--- a/www/src/lib/websocket.js
+++ b/www/src/lib/websocket.js
@@ -12,8 +12,7 @@ export const searchResults = writable({
 });
 export const userPlaylists = writable([])
 
-const position = writable(0);
-const duration = writable(0);
+export const position = writable(0);
 const currentTrackList = writable(null);
 export const currentTrack = derived(currentTrackList, (list) => {
   return list?.queue.find((l) => l.status === "Playing")
@@ -62,7 +61,7 @@ export const entityTitle = derived([currentTrackList, currentTrack], ([tl, c]) =
 
 export const secsToTimecode = (secs) => {
   const minutes = Math.floor(secs / 60);
-  const seconds = Math.floor(secs - (minutes * 60));
+  const seconds = secs - minutes * 60;
 
   return `${minutes.toString(10).padStart(2, 0)}:${seconds.toString(10).padStart(2, 0)}`
 }

--- a/www/src/routes/+page.svelte
+++ b/www/src/routes/+page.svelte
@@ -83,14 +83,12 @@
 {#if $isBuffering || !$connected || $isLoading}
 	<div class="fixed top-8 right-8 z-10">
 		<h1 class="font-semi text-4xl bg-amber-800 leading-none p-2">
-			{#if $isBuffering}
-				BUFFERING
-			{/if}
 			{#if !$connected}
 				DISCONNECTED
-			{/if}
-			{#if $isLoading}
+			{:else if $isLoading}
 				LOADING
+			{:else if $isBuffering}
+				BUFFERING
 			{/if}
 		</h1>
 	</div>


### PR DESCRIPTION
This is maintanance work to primarily clean up the skip logic that hadn't been touched and was overly complicated.

In addition...
- adds target state to loading notification for players
- fixes end of stream not going to first track
- fixes some old code around track playing in the player that was functional but incorrect
- adds a loading icon to the tui and changes the web ui notifications so they don't overlap
- has the resume function wait for the player to reach a paused state before seeking to the last saved position.
- fixes the loading state not working in the web ui
- adds a progress bar to the web ui