### PR TITLE
feat: use wss:// when accessed through HTTPS

### DIFF
--- a/www/src/lib/websocket.js
+++ b/www/src/lib/websocket.js
@@ -87,6 +87,8 @@ export const playlistTitle = writable('');
 export class WS {
   constructor(dev) {
     this.dev = dev;
+    this.secure = location.protocol === 'https:'
+    this.protocol = this.secure ? 'wss:' : 'ws:'
     this.host = dev ? 'localhost:9888' : window.location.host;
 
     this.playPause.bind(this)
@@ -98,7 +100,7 @@ export class WS {
   }
 
   connect() {
-    this.ws = new WebSocket(`ws://${this.host}/ws`);
+    this.ws = new WebSocket(`${this.protocol}//${this.host}/ws`);
     this.ws.onopen = () => {
       connected.set(true);
       this.fetchUserPlaylists()


### PR DESCRIPTION
First of all thank you very much for this project. 

Found it after hours of hair-pulling trying to set up qobuz player through a KVM windoze virtual machine just to get gapless playback.

The PR addresses a small issue I've encountered in my local setup when trying to use HTTPS through a reverse-proxy. 
The websockets protocol was hardcoded to `ws://`, which when accessed through HTTPS will trigger a `DOMException: The operation is insecure.` error in the browser. 

This is a simple fix to dynamically set the proper protocol: `ws://` on plain HTTP, `wss://` on HTTPS.