### PR TITLE
Fix dockerised cross compile

### DIFF
--- a/justfile
+++ b/justfile
@@ -63,7 +63,7 @@ add-target target=detected_target:
   rustup target add {{target}}
 
 install-toolchain kind="stable" target=detected_target:
-  rustup toolchain install {{kind}}-{{target}}
+  rustup toolchain install --force-non-host {{kind}}-{{target}}
 
 install-sqlx:
   cargo install sqlx-cli


### PR DESCRIPTION
The dockerised cross compilation for `aarch64` was not working for me (Debian Trixie on Intel laptop), but adding this option fixed it.