### PR TITLE
Fix search by updating data structure

### DIFF
--- a/hifirs/src/qobuz/mod.rs
+++ b/hifirs/src/qobuz/mod.rs
@@ -56,7 +56,10 @@ impl MusicService for QobuzClient {
     async fn search(&self, query: &str) -> Option<SearchResults> {
         match self.search_all(query, 100).await {
             Ok(results) => Some(results.into()),
-            Err(_) => None,
+            Err(e) => {
+                error!("search failed for {:?}: {}", query, e);
+                None
+            }
         }
     }
 

--- a/qobuz-api/src/client/album.rs
+++ b/qobuz-api/src/client/album.rs
@@ -114,6 +114,7 @@ pub struct Label {
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Genre {
     pub path: Vec<i64>,
+    #[serde(default)]
     pub color: String,
     pub name: String,
     pub id: i64,

--- a/qobuz-api/src/client/api.rs
+++ b/qobuz-api/src/client/api.rs
@@ -577,6 +577,19 @@ impl Client {
         let headers = self.client_headers();
 
         debug!("calling {} endpoint, with params {params:?}", endpoint);
+        let url = if let Some(p) = params {
+            format!(
+                "{}?{}",
+                endpoint,
+                p.iter()
+                    .map(|(k, v)| format!("{k}={v}"))
+                    .collect::<Vec<_>>()
+                    .join("&")
+            )
+        } else {
+            endpoint.to_string()
+        };
+        debug!("GET {url}");
         let request = self.client.request(Method::GET, endpoint).headers(headers);
 
         if let Some(p) = params {
@@ -611,7 +624,11 @@ impl Client {
             Ok(res)
         } else {
             Err(Error::Api {
-                message: response.status().to_string(),
+                message: format!(
+                    "status {}; body: {}",
+                    response.status(),
+                    response.text().await.unwrap_or_default()
+                ),
             })
         }
     }


### PR DESCRIPTION
The search function in the TUI was not working. It turned out there was a mismatch in the 'Genre' data structure that was causing the JSON decoding to fail silently. I've added a bit more diagnostic logging to help track failures like this, and modified the `Genre` structure. I don't even know why the genre has a `color` - maybe this field is never present now, but I've left it as an `option` just in case.